### PR TITLE
Fix command to pull in the email-password template

### DIFF
--- a/docs/04-Reference/02-Graphcool-CLI/02-Commands.md
+++ b/docs/04-Reference/02-Graphcool-CLI/02-Commands.md
@@ -201,7 +201,7 @@ graphcool add-template TEMPLATE
 ##### Pull in the officially supported [`email-password` authentication template](https://github.com/graphcool/templates/tree/master/auth/email-password)
 
 ```sh    
-graphcool add-template graphcool/templates/messaging/email-password
+graphcool add-template graphcool/templates/auth/email-password
 ```
 
 #### Examples


### PR DESCRIPTION
The location of the `email-password` template is `auth/`, not `messaging/`.