### PR TITLE
Improve permission explanations

### DIFF
--- a/examples/permissions/graphcool.yml
+++ b/examples/permissions/graphcool.yml
@@ -2,7 +2,7 @@ types: ./types.graphql
 
 # Permission rules
 permissions:
-  # Everyone can **read** the fields `description` and `imageUrl` 
+  # Everyone can **read** only the fields `description` and `imageUrl` 
   # on nodes of type `Post`
   - operation: Post.read
     fields:
@@ -27,7 +27,7 @@ permissions:
     authenticated: true
     query: src/permissions/Post.graphql:DeletePost
 
-  # Everyone can **read** the fields `email` and `posts` on
+  # Everyone can **read** only the fields `email` and `posts` on
   # nodes of type `User`
   - operation: User.read
     fields: 


### PR DESCRIPTION
Especially the fact that specifying fields on a permission means that the permission applies *only* to those fields.