### PR TITLE
Fixed type declaration syntax on docs (missing @model)

### DIFF
--- a/docs/01-Quickstart/01-Frontend/01-React/01-Apollo.md
+++ b/docs/01-Quickstart/01-Frontend/01-React/01-Apollo.md
@@ -76,7 +76,7 @@ Next you need to configure the [data model](!alias-eiroozae8u) for your service.
 Open `./server/types.graphql` and add the following type definition to it (feel free to delete the existing `User` type):
 
 ```graphql(path="server/types.graphql")
-type Post {
+type Post @model {
   id: ID! @isUnique    # read-only (managed by Graphcool)
   createdAt: DateTime! # read-only (managed by Graphcool)
   updatedAt: DateTime! # read-only (managed by Graphcool)

--- a/docs/01-Quickstart/01-Frontend/01-React/02-Relay.md
+++ b/docs/01-Quickstart/01-Frontend/01-React/02-Relay.md
@@ -76,7 +76,7 @@ Next you need to configure the [data model](!alias-eiroozae8u) for your service.
 Open `./server/types.graphql` and add the following type definition to it (feel free to delete the existing `User` type):
 
 ```graphql(path="server/types.graphql")
-type Post {
+type Post @model {
   id: ID! @isUnique # read-only (managed by Graphcool)
   createdAt: DateTime! # read-only (managed by Graphcool)
   updatedAt: DateTime! # read-only (managed by Graphcool)

--- a/docs/01-Quickstart/01-Frontend/02-React-Native/01-Apollo.md
+++ b/docs/01-Quickstart/01-Frontend/02-React-Native/01-Apollo.md
@@ -75,7 +75,7 @@ Next you need to configure the [data model](!alias-eiroozae8u) for your service.
 Open `./server/types.graphql` and add the following type definition to it (feel free to delete the existing `User` type):
 
 ```graphql(path="server/types.graphql")
-type Post {
+type Post @model {
   id: ID! @isUnique    # read-only (managed by Graphcool)
   createdAt: DateTime! # read-only (managed by Graphcool)
   updatedAt: DateTime! # read-only (managed by Graphcool)

--- a/docs/01-Quickstart/01-Frontend/03-Vue/01-Apollo.md
+++ b/docs/01-Quickstart/01-Frontend/03-Vue/01-Apollo.md
@@ -76,7 +76,7 @@ Next you need to configure the [data model](!alias-eiroozae8u) for your service.
 Open `./server/types.graphql` and add the following type definition to it:
 
 ```graphql(path="server/types.graphql")
-type Post {
+type Post @model {
   id: ID! @isUnique    # read-only (managed by Graphcool)
   createdAt: DateTime! # read-only (managed by Graphcool)
   updatedAt: DateTime! # read-only (managed by Graphcool)

--- a/docs/01-Quickstart/01-Frontend/04-Angular/01-Apollo.md
+++ b/docs/01-Quickstart/01-Frontend/04-Angular/01-Apollo.md
@@ -71,7 +71,7 @@ Next you need to configure the [data model](!alias-eiroozae8u) for your service.
 Open `./server/types.graphql` and add the following type definition to it:
 
 ```graphql(path="server/types.graphql")
-type Post {
+type Post @model {
   id: ID! @isUnique    # read-only (managed by Graphcool)
   createdAt: DateTime! # read-only (managed by Graphcool)
   updatedAt: DateTime! # read-only (managed by Graphcool)

--- a/docs/01-Quickstart/01-Frontend/05-iOS/01-Apollo.md
+++ b/docs/01-Quickstart/01-Frontend/05-iOS/01-Apollo.md
@@ -75,7 +75,7 @@ Next you need to configure the [data model](!alias-eiroozae8u) for your service.
 Open `./server/types.graphql` and add the following type definition to it:
 
 ```graphql(path="")
-type Post {
+type Post @model {
   id: ID! @isUnique    # read-only (managed by Graphcool)
   createdAt: DateTime! # read-only (managed by Graphcool)
   updatedAt: DateTime! # read-only (managed by Graphcool)

--- a/docs/03-Tutorials/02-Auth/02-Authentication-with-Email-and-Password-for-React-&-Apollo.md
+++ b/docs/03-Tutorials/02-Auth/02-Authentication-with-Email-and-Password-for-React-&-Apollo.md
@@ -262,7 +262,7 @@ In addition to the `User` that you got from the `email-password` authentication 
 Open `./server/types.graphql` and add the following definition to it:
 
 ```graphql(path="server/types.graphql")
-type Post {
+type Post @model {
   # Required system field:
   id: ID! @isUnique # read-only (managed by Graphcool)
 


### PR DESCRIPTION
Some type declaration on docs were not using the new syntax, thus when following the tutorial, the user would get the following error when trying to deploy:
```
Creating service server in cluster shared-eu-west-1... ✔
Bundling functions... 2.3s
Deploying... 384ms
There are issues with the new service definition:

  Post
    ✖ The model `Post` is missing the @model directive. Please add it. See: https://github.com/graphcool/graphcool/issues/817
```