### PR TITLE
using topPosts in final query to prevent error

### DIFF
--- a/docs/01-Quickstart/02-Backend/01-TypeScript/01-TypeScript.md
+++ b/docs/01-Quickstart/02-Backend/01-TypeScript/01-TypeScript.md
@@ -233,7 +233,7 @@ To validate it works, you can now send the following query:
       id
       name
     }
-    topPosts (limit:2) {
+    topPosts (limit: 2) {
       title
     }
   }

--- a/docs/01-Quickstart/02-Backend/01-TypeScript/01-TypeScript.md
+++ b/docs/01-Quickstart/02-Backend/01-TypeScript/01-TypeScript.md
@@ -222,7 +222,7 @@ Now that the API gateway is deployed, you can send the exposed queries to it.
 
 <Instruction> 
 
-Open a Playground for the API gateway by navigatint to [`http://localhost:3000/playground`](http://localhost:3000/playground) inside your browser.
+Open a Playground for the API gateway by navigating to [`http://localhost:3000/playground`](http://localhost:3000/playground) inside your browser.
 
 To validate it works, you can now send the following query:
 
@@ -232,9 +232,9 @@ To validate it works, you can now send the following query:
     me {
       id
       name
-      posts(limit: 2) {
-        title
-      }
+    }
+    topPosts (limit:2) {
+      title
     }
   }
 }

--- a/examples/typescript-gateway-custom-schema/README.md
+++ b/examples/typescript-gateway-custom-schema/README.md
@@ -119,9 +119,9 @@ Send the following query to fetch the posts that you just created:
     me {
       id
       name
-      posts(limit: 2) {
-        title
-      }
+    }
+    topPosts (limit: 2) {
+      title
     }
   }
 }


### PR DESCRIPTION
given the latest sample code, the final query in this quickstart guide was generating the following error:
`Unknown argument "limit" on field "posts" of type "User"`

this could be fixed by removing the limit, or by requesting topPosts one level up on the viewer model. i went with the latter option as it also demonstrates the limit, rather than simply returning all posts. also corrected a very minor typo in a sentence above this.