### PR TITLE
Add Aliases to Permission Whitelist

### DIFF
--- a/server/backend-shared/src/main/scala/cool/graph/client/MutationQueryWhitelist.scala
+++ b/server/backend-shared/src/main/scala/cool/graph/client/MutationQueryWhitelist.scala
@@ -1,5 +1,7 @@
 package cool.graph.client
 
+import java.io
+
 import cool.graph.RequestContextTrait
 import sangria.schema.Context
 
@@ -16,16 +18,24 @@ class MutationQueryWhitelist {
       case None          => ctx.args.raw.keys.toSet
     }
 
-    this.paths = pathsToNode.map(mutationName +: _)
+    val mutationNamePaths: List[List[String]] = pathsToNode.map(mutationName +: _)
+
+    val alias: Option[String] = ctx.astFields.find(_.name == mutationName).flatMap(_.alias)
+
+    val aliasPath: List[List[String]] = alias match {
+      case Some(a) => pathsToNode.map(a +: _)
+      case None => List(List.empty)
+    }
+
+    this.paths = mutationNamePaths ++ aliasPath
   }
 
   def isMutationQuery = _isMutationQuery
 
-  def isWhitelisted(path: Vector[Any]) = {
-    path.reverse.toList match {
-      case (field: String) :: pathToNode if paths.contains(pathToNode.reverse) =>
-        fields.contains(field) || field == "id"
-      case _ => false
-    }
+  def isWhitelisted(path: Vector[Any]) = path.reverse.toList match {
+    case (field: String) :: pathToNode if paths.contains(pathToNode.reverse) =>
+      fields.contains(field) || field == "id"
+    case _ => false
   }
+
 }

--- a/server/backend-shared/src/main/scala/cool/graph/client/MutationQueryWhitelist.scala
+++ b/server/backend-shared/src/main/scala/cool/graph/client/MutationQueryWhitelist.scala
@@ -1,7 +1,5 @@
 package cool.graph.client
 
-import java.io
-
 import cool.graph.RequestContextTrait
 import sangria.schema.Context
 
@@ -19,12 +17,11 @@ class MutationQueryWhitelist {
     }
 
     val mutationNamePaths: List[List[String]] = pathsToNode.map(mutationName +: _)
-
-    val alias: Option[String] = ctx.astFields.find(_.name == mutationName).flatMap(_.alias)
+    val alias: Option[String]                 = ctx.astFields.find(_.name == mutationName).flatMap(_.alias)
 
     val aliasPath: List[List[String]] = alias match {
       case Some(a) => pathsToNode.map(a +: _)
-      case None => List(List.empty)
+      case None    => List(List.empty)
     }
 
     this.paths = mutationNamePaths ++ aliasPath
@@ -35,7 +32,9 @@ class MutationQueryWhitelist {
   def isWhitelisted(path: Vector[Any]) = path.reverse.toList match {
     case (field: String) :: pathToNode if paths.contains(pathToNode.reverse) =>
       fields.contains(field) || field == "id"
-    case _ => false
+
+    case _ =>
+      false
   }
 
 }

--- a/server/client-shared/src/main/scala/cool/graph/client/schema/SchemaBuilder.scala
+++ b/server/client-shared/src/main/scala/cool/graph/client/schema/SchemaBuilder.scala
@@ -32,7 +32,7 @@ import scala.concurrent.Future
 abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(implicit inj: Injector,
                                                                                 actorSystem: ActorSystem,
                                                                                 materializer: ActorMaterializer)
-  extends Injectable
+    extends Injectable
     with TimeHelper {
 
   type ManyDataItemType
@@ -67,16 +67,7 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
   val pluralsCache           = new PluralsCache
 
   def ifFeatureFlag(predicate: Boolean, fields: => List[Field[UserContext, Unit]], measurementName: String = ""): List[Field[UserContext, Unit]] = {
-    if (predicate) {
-      //      if(measurementName != ""){
-      //        time(measurementName)(fields)
-      //      } else {
-      //        fields
-      //      }
-      fields
-    } else {
-      List.empty
-    }
+    if (predicate) fields else List.empty
   }
 
   def build(): Schema[UserContext, Unit] = ClientSharedMetrics.schemaBuilderBuildTimerMetric.time(project.id) {
@@ -364,11 +355,11 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
       arguments = arguments,
       resolve = (ctx) =>
         new SetRelation(relation = relation,
-          fromModel = fromModel,
-          project = project,
-          args = ctx.args,
-          dataResolver = ctx.ctx.dataResolver,
-          argumentSchema = argumentSchema)
+                        fromModel = fromModel,
+                        project = project,
+                        args = ctx.args,
+                        dataResolver = ctx.ctx.dataResolver,
+                        argumentSchema = argumentSchema)
           .run(ctx.ctx.authenticatedRequest, ctx.ctx)
           .map(outputMapper.mapResolve(_, ctx.args))
     )
@@ -389,11 +380,11 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
       arguments = arguments,
       resolve = (ctx) =>
         new AddToRelation(relation = relation,
-          fromModel = fromModel,
-          project = project,
-          args = ctx.args,
-          dataResolver = ctx.ctx.dataResolver,
-          argumentSchema = argumentSchema)
+                          fromModel = fromModel,
+                          project = project,
+                          args = ctx.args,
+                          dataResolver = ctx.ctx.dataResolver,
+                          argumentSchema = argumentSchema)
           .run(ctx.ctx.authenticatedRequest, ctx.ctx)
           .map(outputMapper.mapResolve(_, ctx.args))
     )
@@ -416,11 +407,11 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
       arguments = arguments,
       resolve = (ctx) =>
         new RemoveFromRelation(relation = relation,
-          fromModel = fromModel,
-          project = project,
-          args = ctx.args,
-          dataResolver = ctx.ctx.dataResolver,
-          argumentSchema = argumentSchema)
+                               fromModel = fromModel,
+                               project = project,
+                               args = ctx.args,
+                               dataResolver = ctx.ctx.dataResolver,
+                               argumentSchema = argumentSchema)
           .run(ctx.ctx.authenticatedRequest, ctx.ctx)
           .map(outputMapper.mapResolve(_, ctx.args))
     )
@@ -442,11 +433,11 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
       arguments = arguments,
       resolve = (ctx) =>
         new UnsetRelation(relation = relation,
-          fromModel = fromModel,
-          project = project,
-          args = ctx.args,
-          dataResolver = ctx.ctx.dataResolver,
-          argumentSchema = argumentSchema)
+                          fromModel = fromModel,
+                          project = project,
+                          args = ctx.args,
+                          dataResolver = ctx.ctx.dataResolver,
+                          argumentSchema = argumentSchema)
           .run(ctx.ctx.authenticatedRequest, ctx.ctx)
           .map(outputMapper.mapResolve(_, ctx.args))
     )
@@ -500,11 +491,11 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
       resolve = (ctx) => {
         ctx.ctx.mutationQueryWhitelist.registerWhitelist(s"delete${model.name}", outputMapper.nodePaths(model), argumentSchema.inputWrapper, ctx)
         new Delete(model = model,
-          modelObjectTypes = modelObjectTypesBuilder,
-          project = project,
-          args = ctx.args,
-          dataResolver = ctx.ctx.dataResolver,
-          argumentSchema = argumentSchema)
+                   modelObjectTypes = modelObjectTypesBuilder,
+                   project = project,
+                   args = ctx.args,
+                   dataResolver = ctx.ctx.dataResolver,
+                   argumentSchema = argumentSchema)
           .run(ctx.ctx.authenticatedRequest, ctx.ctx)
           .map(outputMapper.mapResolve(_, ctx.args))
       }

--- a/server/client-shared/src/main/scala/cool/graph/client/schema/SchemaBuilder.scala
+++ b/server/client-shared/src/main/scala/cool/graph/client/schema/SchemaBuilder.scala
@@ -15,10 +15,11 @@ import cool.graph.shared.errors.UserAPIErrors
 import cool.graph.shared.errors.UserInputErrors.InvalidSchema
 import cool.graph.shared.functions.EndpointResolver
 import cool.graph.shared.models.{Field => GCField, _}
-import cool.graph.shared.{DefaultApiMatrix, ApiMatrixFactory, models}
+import cool.graph.shared.{ApiMatrixFactory, DefaultApiMatrix, models}
 import cool.graph.util.coolSangria.FromInputImplicit
 import cool.graph.util.performance.TimeHelper
 import org.atteo.evo.inflector.English
+import sangria.ast.Definition
 import sangria.relay._
 import sangria.schema.{Field, _}
 import scaldi.{Injectable, Injector}
@@ -31,7 +32,7 @@ import scala.concurrent.Future
 abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(implicit inj: Injector,
                                                                                 actorSystem: ActorSystem,
                                                                                 materializer: ActorMaterializer)
-    extends Injectable
+  extends Injectable
     with TimeHelper {
 
   type ManyDataItemType
@@ -67,11 +68,11 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
 
   def ifFeatureFlag(predicate: Boolean, fields: => List[Field[UserContext, Unit]], measurementName: String = ""): List[Field[UserContext, Unit]] = {
     if (predicate) {
-//      if(measurementName != ""){
-//        time(measurementName)(fields)
-//      } else {
-//        fields
-//      }
+      //      if(measurementName != ""){
+      //        time(measurementName)(fields)
+      //      } else {
+      //        fields
+      //      }
       fields
     } else {
       List.empty
@@ -300,7 +301,7 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
       .batchResolveByUnique(model, arg.name, List(ctx.arg(arg).asInstanceOf[Option[_]].get))
       .map(_.headOption)
     // todo: Make OneDeferredResolver.dataItemsToToOneDeferredResultType work with Timestamps
-//    OneDeferred(model, arg.name, ctx.arg(arg).asInstanceOf[Option[_]].get)
+    //    OneDeferred(model, arg.name, ctx.arg(arg).asInstanceOf[Option[_]].get)
   }
 
   def createSingleFieldTypeForModel(model: models.Model) =
@@ -363,11 +364,11 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
       arguments = arguments,
       resolve = (ctx) =>
         new SetRelation(relation = relation,
-                        fromModel = fromModel,
-                        project = project,
-                        args = ctx.args,
-                        dataResolver = ctx.ctx.dataResolver,
-                        argumentSchema = argumentSchema)
+          fromModel = fromModel,
+          project = project,
+          args = ctx.args,
+          dataResolver = ctx.ctx.dataResolver,
+          argumentSchema = argumentSchema)
           .run(ctx.ctx.authenticatedRequest, ctx.ctx)
           .map(outputMapper.mapResolve(_, ctx.args))
     )
@@ -388,11 +389,11 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
       arguments = arguments,
       resolve = (ctx) =>
         new AddToRelation(relation = relation,
-                          fromModel = fromModel,
-                          project = project,
-                          args = ctx.args,
-                          dataResolver = ctx.ctx.dataResolver,
-                          argumentSchema = argumentSchema)
+          fromModel = fromModel,
+          project = project,
+          args = ctx.args,
+          dataResolver = ctx.ctx.dataResolver,
+          argumentSchema = argumentSchema)
           .run(ctx.ctx.authenticatedRequest, ctx.ctx)
           .map(outputMapper.mapResolve(_, ctx.args))
     )
@@ -415,11 +416,11 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
       arguments = arguments,
       resolve = (ctx) =>
         new RemoveFromRelation(relation = relation,
-                               fromModel = fromModel,
-                               project = project,
-                               args = ctx.args,
-                               dataResolver = ctx.ctx.dataResolver,
-                               argumentSchema = argumentSchema)
+          fromModel = fromModel,
+          project = project,
+          args = ctx.args,
+          dataResolver = ctx.ctx.dataResolver,
+          argumentSchema = argumentSchema)
           .run(ctx.ctx.authenticatedRequest, ctx.ctx)
           .map(outputMapper.mapResolve(_, ctx.args))
     )
@@ -441,11 +442,11 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
       arguments = arguments,
       resolve = (ctx) =>
         new UnsetRelation(relation = relation,
-                          fromModel = fromModel,
-                          project = project,
-                          args = ctx.args,
-                          dataResolver = ctx.ctx.dataResolver,
-                          argumentSchema = argumentSchema)
+          fromModel = fromModel,
+          project = project,
+          args = ctx.args,
+          dataResolver = ctx.ctx.dataResolver,
+          argumentSchema = argumentSchema)
           .run(ctx.ctx.authenticatedRequest, ctx.ctx)
           .map(outputMapper.mapResolve(_, ctx.args))
     )
@@ -499,11 +500,11 @@ abstract class SchemaBuilder(project: models.Project, modelPrefix: String = "")(
       resolve = (ctx) => {
         ctx.ctx.mutationQueryWhitelist.registerWhitelist(s"delete${model.name}", outputMapper.nodePaths(model), argumentSchema.inputWrapper, ctx)
         new Delete(model = model,
-                   modelObjectTypes = modelObjectTypesBuilder,
-                   project = project,
-                   args = ctx.args,
-                   dataResolver = ctx.ctx.dataResolver,
-                   argumentSchema = argumentSchema)
+          modelObjectTypes = modelObjectTypesBuilder,
+          project = project,
+          args = ctx.args,
+          dataResolver = ctx.ctx.dataResolver,
+          argumentSchema = argumentSchema)
           .run(ctx.ctx.authenticatedRequest, ctx.ctx)
           .map(outputMapper.mapResolve(_, ctx.args))
       }

--- a/server/client-shared/src/test/scala/cool/graph/private_api/finder/CachedProjectFetcherImplSpec.scala
+++ b/server/client-shared/src/test/scala/cool/graph/private_api/finder/CachedProjectFetcherImplSpec.scala
@@ -58,7 +58,7 @@ class CachedProjectFetcherImplSpec extends FlatSpec with Matchers with ScalaFutu
     projectFetcher.setAlias(firstAlias = None, secondAlias = None)
     pubSub.publish(Only("FirstOne"), "FirstOne")
 
-    Thread.sleep(2000)
+    Thread.sleep(3000)
 
     //fetch second time with alias -> this should not find anything now
     cachedProjectFetcher.fetch("FirstAlias").futureValue should be(None)

--- a/server/client-shared/src/test/scala/cool/graph/private_api/finder/CachedProjectFetcherImplSpec.scala
+++ b/server/client-shared/src/test/scala/cool/graph/private_api/finder/CachedProjectFetcherImplSpec.scala
@@ -1,9 +1,11 @@
 package cool.graph.private_api.finder
 
+import akka.actor.ActorSystem
 import cool.graph.akkautil.SingleThreadedActorSystem
 import cool.graph.bugsnag.BugSnaggerImpl
 import cool.graph.client.finder.{CachedProjectFetcherImpl, RefreshableProjectFetcher}
 import cool.graph.messagebus.Conversions
+import cool.graph.messagebus.Conversions.{ByteMarshaller, ByteUnmarshaller}
 import cool.graph.messagebus.pubsub.Only
 import cool.graph.messagebus.pubsub.rabbit.RabbitAkkaPubSub
 import cool.graph.messagebus.testkits.DummyPubSubSubscriber
@@ -14,15 +16,15 @@ import org.scalatest.{FlatSpec, Matchers}
 import scala.concurrent.{Await, Awaitable, Future}
 
 class CachedProjectFetcherImplSpec extends FlatSpec with Matchers with ScalaFutures {
-  implicit val system                     = SingleThreadedActorSystem("cacheSpec")
+  implicit val system: ActorSystem = SingleThreadedActorSystem("cacheSpec")
   implicit val bugsnagger: BugSnaggerImpl = BugSnaggerImpl("")
-  implicit val unmarshaller               = Conversions.Unmarshallers.ToString
-  implicit val marshaller                 = Conversions.Marshallers.FromString
+  implicit val unmarshaller: ByteUnmarshaller[String] = Conversions.Unmarshallers.ToString
+  implicit val marshaller: ByteMarshaller[String] = Conversions.Marshallers.FromString
 
   val database = ProjectDatabase(id = "test", region = Region.EU_WEST_1, name = "client1", isDefaultForRegion = true)
   val project = Project(id = "", ownerId = "", name = s"Test Project", alias = None, projectDatabase = database)
-  val rabbitUri                        = sys.env.getOrElse("RABBITMQ_URI", sys.error("RABBITMQ_URI env var required but not found"))
-  val projectFetcher                   = new ProjectFetcherMock(project)
+  val rabbitUri: String = sys.env.getOrElse("RABBITMQ_URI", sys.error("RABBITMQ_URI env var required but not found"))
+  val projectFetcher: ProjectFetcherMock = new ProjectFetcherMock(project)
   val pubSub: RabbitAkkaPubSub[String] = RabbitAkkaPubSub[String](rabbitUri, "project-schema-invalidation", durable = true)
 
   "it" should "work" in {
@@ -78,18 +80,18 @@ class CachedProjectFetcherImplSpec extends FlatSpec with Matchers with ScalaFutu
     pubSub.publish(Only("FirstOne"), "FirstOne")
     pubSub.publish(Only("SecondOne"), "SecondOne")
 
-    Thread.sleep(1000)
+    Thread.sleep(2000)
 
     //fetch second time with alias -> this should not find anything now since project needs to be found once by id first
     val fetchByAlias = cachedProjectFetcher.fetch("FirstAlias").futureValue
     fetchByAlias should be(None)
 
-    Thread.sleep(1000)
+    Thread.sleep(2000)
     //load alias cache by loading by id first once
     val fetchById = cachedProjectFetcher.fetch("SecondOne").futureValue
     fetchById.get.project.id should be("SecondOne")
 
-    Thread.sleep(1000)
+    Thread.sleep(2000)
     // this should now find the SecondOne
     val fetchByAliasAgain = cachedProjectFetcher.fetch("FirstAlias").futureValue
     fetchByAliasAgain.get.project.id should be("SecondOne")


### PR DESCRIPTION
* currently making use of an alias in a mutation results in a permission error if no read permissions for created fields are set
* but creating a field should always whitelist that path for the permission check