### PR TITLE
allow function to return anything, even nothing in local mode

### DIFF
--- a/cli/packages/graphcool-cli-core/src/commands/deploy/Bundler/proxies/dev.js
+++ b/cli/packages/graphcool-cli-core/src/commands/deploy/Bundler/proxies/dev.js
@@ -63,7 +63,7 @@ function cb(error, value) {
 function executeFunction(fn, event, cb) {
   try {
     var promise = fn(event)
-    if (typeof promise.then === 'function') {
+    if (promise && typeof promise.then === 'function') {
       promise.then(function (data) {
         cb(null, data)
       }).catch(function (error) {


### PR DESCRIPTION
In local execution, the function called needed to return something. If the function didn't return anything we had a `Cannot read property 'then' of undefined`.

Like that now we can handle properly the functions that return nothing (really useful in subscription functions for exemple)