### PR TITLE
SimpleHttpClient cleanup

### DIFF
--- a/server/backend-api-system/src/main/scala/cool/graph/system/externalServices/AlgoliaKeyChecker.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/externalServices/AlgoliaKeyChecker.scala
@@ -2,7 +2,7 @@ package cool.graph.system.externalServices
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, StreamTcpException}
-import cool.graph.akkautil.http.{FailedRequestError, SimpleHttpClient}
+import cool.graph.akkautil.http.{RequestFailedError, SimpleHttpClient}
 import scaldi.{Injectable, Injector}
 import spray.json.DefaultJsonProtocol
 
@@ -51,7 +51,7 @@ class AlgoliaKeyCheckerImplementation(implicit inj: Injector) extends AlgoliaKey
         .recover {
           // https://[INVALID].algolia.net/1/keys/[VALID] times out, so we simply report a timeout as a wrong appId
           case _: StreamTcpException => false
-          case _: FailedRequestError => false
+          case _: RequestFailedError => false
         }
     }
   }

--- a/server/backend-workers/src/main/scala/cool/graph/worker/workers/WebhookDelivererWorker.scala
+++ b/server/backend-workers/src/main/scala/cool/graph/worker/workers/WebhookDelivererWorker.scala
@@ -1,7 +1,7 @@
 package cool.graph.worker.workers
 
 import akka.http.scaladsl.model.ContentTypes
-import cool.graph.akkautil.http.{FailedRequestError, SimpleHttpClient}
+import cool.graph.akkautil.http.{RequestFailedError, SimpleHttpClient}
 import cool.graph.bugsnag.BugSnagger
 import cool.graph.cuid.Cuid
 import cool.graph.messagebus.{QueueConsumer, QueuePublisher}
@@ -44,7 +44,7 @@ case class WebhookDelivererWorker(
         logsPublisher.publish(logItem)
       }
       .recover {
-        case e: FailedRequestError =>
+        case e: RequestFailedError =>
           val message =
             s"Call to ${wh.url} failed with status ${e.response.status}, response body '${e.response.body.getOrElse("")}' and headers [${formatHeaders(e.response.headers)}]"
           handleError(message)


### PR DESCRIPTION
- Minor semantic change to SimpleHttpClient: Distinguish certain failure conditions (status code, request unmarshalling) directly in the error classes.
- Replace an akka HTTP implemenation in FunctionExecutor (that I missed earlier) with SimpleHttpClient.