### PR TITLE
Allow shortcut for webhook url definition if no headers are present

### DIFF
--- a/server/backend-api-system/src/main/scala/cool/graph/system/migration/ProjectConfig.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/migration/ProjectConfig.scala
@@ -425,6 +425,9 @@ object ProjectConfig {
 
           val handler = if (fields(YamlString("handler")).asYamlObject.fields.get(YamlString("code")).exists(_.isInstanceOf[YamlString])) {
             FunctionHandler(code = Some(FunctionHandlerCode(src = fields(YamlString("handler")).asYamlObject.fields(YamlString("code")).convertTo[String])))
+          } else if (fields(YamlString("handler")).asYamlObject.fields.get(YamlString("webhook")).exists(_.isInstanceOf[YamlString])) {
+            FunctionHandler(
+              webhook = Some(FunctionHandlerWebhook(url = fields(YamlString("handler")).asYamlObject.fields(YamlString("webhook")).convertTo[String])))
           } else {
             fields(YamlString("handler")).convertTo[FunctionHandler]
           }


### PR DESCRIPTION
In addition to 

```yaml
types: ./types.graphql
functions:
  WebhookFunction:
    isEnabled: true
    handler:
      webhook:
        url: http://some.url
    type: operationBefore
    operation: "TestModel.create"
permissions: []
rootTokens: []
``` 

this is now also enabled

```yaml
types: ./types.graphql
functions:
  WebhookFunction:
    isEnabled: true
    handler:
      webhook: http://some.url
    type: operationBefore
    operation: "TestModel.create"
permissions: []
rootTokens: []
```

