### PR TITLE
[WIP] Rabbit-backed tests to in-memory-backed tests

### DIFF
--- a/server/libs/message-bus/src/main/scala/cool/graph/messagebus/testkits/InMemoryPubSubTestKit.scala
+++ b/server/libs/message-bus/src/main/scala/cool/graph/messagebus/testkits/InMemoryPubSubTestKit.scala
@@ -5,17 +5,23 @@ import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
 import cool.graph.messagebus.Conversions.Converter
 import cool.graph.messagebus.PubSub
+import cool.graph.messagebus.pubsub._
 import cool.graph.messagebus.pubsub.inmemory.InMemoryAkkaPubSub
-import cool.graph.messagebus.pubsub.{Message, Only, Subscription, Topic}
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.existentials
 import scala.reflect.ClassTag
 
 /**
-  * InMemory testkit for simple test cases that requires reasoning over published or received messages.
+  * InMemory testkit for simple test cases that requires reasoning over published or received messages for a PubSub.
   * Intercepts all messages transparently.
+  *
+  * The overall interface is intentionally close to akka testkit, and leverages TestProbes internally
+  * to use and combine akka testkit calls to reason over pub sub messages.
+  *
+  * Messages published to the pubsub and received by the subscribers are stored in separate collections
+  * messagesReceived and messagesPublished. Each expect call on this testkit has a version for
+  * for published messages and for received messages.
   */
 case class InMemoryPubSubTestKit[T]()(
     implicit tag: ClassTag[T],
@@ -26,57 +32,139 @@ case class InMemoryPubSubTestKit[T]()(
 
   val probe             = TestProbe() // Received messages
   val publishProbe      = TestProbe() // Published messages
-  val logId             = new java.util.Random().nextInt() // For log output correlation
+  val logId             = new java.util.Random().nextInt(Integer.MAX_VALUE) // For log output correlation
   var messagesReceived  = Vector.empty[Message[T]]
   var messagesPublished = Vector.empty[Message[T]]
   val _underlying       = InMemoryAkkaPubSub[T]()
 
+  // todo: Set semantics required for the messages! If multiple subscribers receive the same message,
+
   /**
-    * For expecting a specific message in the queue with given value in the main queue.
+    * Subscribes a dummy test subscriber that listens to all messages on the PubSub, stores them
+    * in the messagesReceived, and notifies the probe.
+    */
+  def withTestSubscriber: Unit = subscribe(Everything, msg => /* noop */ ())
+
+  /**
+    * Subscribes a custom callback that will be invoked when a message arrives for the given topic.
+    * The subscriber is wrapped transparently by the necessary logic to store messages and notify the test probe, so the
+    * callback does not need to implement that logic. Hence, all expect calls will just work as usual with the
+    * custom subscriber.
+    *
+    * This is usually used in test cases that test code without subscribers, which require custom logic for
+    * processing messages in tests.
+    */
+  override def subscribe(topic: Topic, onReceive: (Message[T]) => Unit): Subscription = {
+    _underlying.subscribe(
+      topic, { msg: Message[T] =>
+        println(s"[TestKit][$logId] Received $msg")
+
+        messagesReceived.synchronized {
+          messagesReceived = messagesReceived :+ msg
+        }
+
+        probe.ref ! msg
+        onReceive(msg)
+      }
+    )
+  }
+
+  /**
+    * Subscribes a custom actor that will receive incoming message for the given topic.
+    * The subscriber is wrapped transparently by the necessary logic to store messages and notify the test probe, so the
+    * actor does not need to implement that logic. Hence, all expect calls will just work as usual with the
+    * custom actor.
+    *
+    * This is usually used in test cases that test code without subscribers, which require custom logic for
+    * processing messages in tests.
+    */
+  override def subscribe(topic: Topic, subscriber: ActorRef): Subscription = {
+    _underlying.subscribe(
+      topic, { msg: Message[T] =>
+        println(s"[TestKit][$logId] Received $msg")
+
+        messagesReceived.synchronized {
+          messagesReceived = messagesReceived :+ msg
+        }
+
+        probe.ref ! msg
+        subscriber ! msg
+      }
+    )
+  }
+
+  /**
+    * For expecting a specific message to arrive at subscribers in the PubSub with given value.
+    * Requires at least one subscriber to be meaningful.
     */
   def expectMsg(msg: Message[T], maxWait: FiniteDuration = 6.seconds): Message[T] = probe.expectMsg(maxWait, msg)
 
-  def expectPublishedMessage(msg: Message[T], maxWait: FiniteDuration = 6.seconds): Unit = publishProbe.expectMsg(maxWait, msg)
+  /**
+    * For expecting a specific message to be published to the PubSub with given value.
+    * Does _not_ require a subscriber to be meaningful.
+    */
+  def expectPublishedMsg(msg: Message[T], maxWait: FiniteDuration = 6.seconds): Unit = publishProbe.expectMsg(maxWait, msg)
 
   /**
-    * For expecting no message in the given timeframe.
+    * For expecting that no message arrived _at any subscriber_ in the given time frame.
+    * Requires at least one subscriber to be meaningful.
     */
   def expectNoMsg(maxWait: FiniteDuration = 6.seconds): Unit = {
     probe.expectNoMsg(maxWait)
   }
 
-  def expectNoPublishedMessage(maxWait: FiniteDuration = 6.seconds): Unit = {
+  /**
+    * For expecting that no message was published to the PubSub in the given time frame.
+    * Does _not_ require a subscriber to be meaningful.
+    */
+  def expectNoPublishedMsg(maxWait: FiniteDuration = 6.seconds): Unit = {
     publishProbe.expectNoMsg(maxWait)
   }
 
   /**
-    * Expects a number of messages to arrive.
-    * Matches the total count received in the time frame, so too many messages is also a failure.
+    * Expects a number of messages to arrive _at any subscriber_ in the given time frame (count is across all subscribers).
+    * Matches the total count received in the time frame, so too many messages results in a failure.
+    *
+    * Requires at least one subscriber to be meaningful.
     */
   def expectMsgCount(count: Int, maxWait: FiniteDuration = 6.seconds): Unit = {
     probe.expectMsgAllClassOf(maxWait, Array.fill(count)(messageTag.runtimeClass): _*)
     probe.expectNoMsg(maxWait)
   }
 
+  /**
+    * Expects a number of messages to be published to the PubSub in the given time frame.
+    * Matches the total count received in the time frame, so too many messages results in a failure.
+    *
+    * Does _not_ require a subscriber to be meaningful.
+    */
   def expectPublishCount(count: Int, maxWait: FiniteDuration = 6.seconds): Unit = {
     publishProbe.expectMsgAllClassOf(maxWait, Array.fill(count)(messageTag.runtimeClass): _*)
     publishProbe.expectNoMsg(maxWait)
   }
 
-  def fishForMessage(msg: Message[T], maxWait: FiniteDuration = 6.seconds) =
+  /**
+    * Waits for a specific message to arrive _at any subscriber_ for a maximum of maxWait duration.
+    * Requires at least one subscriber to be meaningful.
+    */
+  def fishForMsg(msg: Message[T], maxWait: FiniteDuration = 6.seconds) =
     probe.fishForMessage(maxWait) {
       case expected: Message[T] if expected == msg => true
       case _                                       => false
     }
 
-  def fishForPublishedMessage(msg: Message[T], maxWait: FiniteDuration = 6.seconds) =
+  /**
+    * Waits for a specific message to be published to this queue for a maximum of maxWait duration.
+    * Does not require a subscriber to be meaningful.
+    */
+  def fishForPublishedMsg(msg: Message[T], maxWait: FiniteDuration = 6.seconds) =
     publishProbe.fishForMessage(maxWait) {
       case expected: Message[T] if expected == msg => true
       case _                                       => false
     }
 
   /**
-    * Regular publish of messages. Publishes to the main queue.
+    * Publish a message to this pubsub.
     */
   def publish(topic: Only, msg: T): Unit = {
     val wrapped = Message(topic.topic, msg)
@@ -94,41 +182,8 @@ case class InMemoryPubSubTestKit[T]()(
     messagesPublished = Vector.empty[Message[T]]
 
     _underlying.shutdown
-
-    Await.result(system.terminate(), 10.seconds)
-  }
-
-  override def subscribe(topic: Topic, onReceive: (Message[T]) => Unit): Subscription = {
-    _underlying.subscribe(
-      topic, { msg: Message[T] =>
-        println(s"[TestKit][$logId] Received $msg")
-
-        messagesReceived.synchronized {
-          messagesReceived = messagesReceived :+ msg
-        }
-
-        probe.ref ! msg
-        onReceive(msg)
-      }
-    )
-  }
-
-  override def subscribe(topic: Topic, subscriber: ActorRef): Subscription = {
-    _underlying.subscribe(
-      topic, { msg: Message[T] =>
-        println(s"[TestKit][$logId] Received $msg")
-
-        messagesReceived.synchronized {
-          messagesReceived = messagesReceived :+ msg
-        }
-
-        probe.ref ! msg
-        subscriber ! msg
-      }
-    )
   }
 
   override def subscribe[U](topic: Topic, subscriber: ActorRef, converter: Converter[T, U]): Subscription = ???
-
-  override def unsubscribe(subscription: Subscription): Unit = subscription.unsubscribe
+  override def unsubscribe(subscription: Subscription): Unit                                              = subscription.unsubscribe
 }

--- a/server/libs/message-bus/src/main/scala/cool/graph/messagebus/testkits/InMemoryQueueTestKit.scala
+++ b/server/libs/message-bus/src/main/scala/cool/graph/messagebus/testkits/InMemoryQueueTestKit.scala
@@ -8,13 +8,21 @@ import cool.graph.messagebus.queue.inmemory.InMemoryAkkaQueue
 import cool.graph.messagebus.queue.{BackoffStrategy, ConstantBackoff}
 import cool.graph.messagebus.{ConsumerRef, Queue}
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
 import scala.language.existentials
 import scala.reflect.ClassTag
 
 /**
-  * InMemory testkit for simple test cases that requires reasoning over published or received messages.
+  * InMemory testkit for simple test cases that requires reasoning over published or received messages for a Queue.
+  * Intercepts all messages transparently.
+  *
+  * The overall interface is intentionally close to akka testkit, and leverages TestProbes internally
+  * to use and combine akka testkit calls to reason over queue messages.
+  *
+  * Messages published to the queue and received by the registered consumers are stored in separate collections
+  * messagesReceived and messagesPublished. Each expect call on this testkit has a version for
+  * for published messages and for incoming messages.
   */
 case class InMemoryQueueTestKit[T](backoff: BackoffStrategy = ConstantBackoff(1.second))(
     implicit tag: ClassTag[T],
@@ -25,11 +33,17 @@ case class InMemoryQueueTestKit[T](backoff: BackoffStrategy = ConstantBackoff(1.
 
   val probe             = TestProbe() // Receives messages
   val publishProbe      = TestProbe() // Receives published messages
-  val logId             = new java.util.Random().nextInt() // For log output correlation
+  val logId             = new java.util.Random().nextInt(Integer.MAX_VALUE) // For log output correlation
   var messagesReceived  = Vector.empty[T]
   var messagesPublished = Vector.empty[T]
   val _underlying       = InMemoryAkkaQueue[T]()
 
+  /**
+    * Registers the standard test consumer that just stores the incoming messages in messagesReceived and notifies the
+    * consumer probe.
+    *
+    * This is usually used in test cases that test code without consumer registration.
+    */
   def withTestConsumer(): Unit = {
     _underlying
       .withConsumer { msg: T =>
@@ -45,6 +59,15 @@ case class InMemoryQueueTestKit[T](backoff: BackoffStrategy = ConstantBackoff(1.
       }
   }
 
+  /**
+    * Registers a custom consumer that will be invoked on message receive.
+    * The consumer is wrapped transparently by the necessary logic to store messages and notify the test probe, so the
+    * consume callback does not need to implement that logic. Hence, all expect calls will just work as usual with the
+    * custom consumer.
+    *
+    * This is usually used in test cases that test code without consumer registration, which require custom logic for
+    * processing messages in tests.
+    */
   override def withConsumer(fn: ConsumeFn[T]): ConsumerRef = {
     _underlying.withConsumer { msg: T =>
       probe.ref ! msg
@@ -58,51 +81,79 @@ case class InMemoryQueueTestKit[T](backoff: BackoffStrategy = ConstantBackoff(1.
   }
 
   /**
-    * For expecting a specific message in the queue with given value in the main queue.
+    * For expecting a specific message to arrive _at any consumer_ in the given time frame.
+    * Requires at least one consumer to be meaningful.
     */
   def expectMsg(msg: T, maxWait: FiniteDuration = 6.seconds): T = probe.expectMsg(maxWait, msg)
 
-  def expectPublishedMessage(msg: T, maxWait: FiniteDuration = 6.seconds): Unit = publishProbe.expectMsg(maxWait, msg)
+  /**
+    * For expecting a specific message to be published to the queue in the given time frame.
+    * Does not require a consumer to be meaningful.
+    */
+  def expectPublishedMsg(msg: T, maxWait: FiniteDuration = 6.seconds): Unit = publishProbe.expectMsg(maxWait, msg)
 
   /**
-    * For expecting no message in the given timeframe.
+    * For expecting no message to arrive _at any consumer_ in the given time frame.
+    * Requires at least one consumer to be meaningful.
     */
   def expectNoMsg(maxWait: FiniteDuration = 6.seconds): Unit = {
     probe.expectNoMsg(maxWait)
   }
 
-  def expectNoPublishedMessage(maxWait: FiniteDuration = 6.seconds): Unit = {
+  /**
+    * For expecting no message to be published to the queue in the given time frame.
+    * Does not require a consumer to be meaningful.
+    */
+  def expectNoPublishedMsg(maxWait: FiniteDuration = 6.seconds): Unit = {
     publishProbe.expectNoMsg(maxWait)
   }
 
   /**
-    * Expects a number of messages to arrive.
-    * Matches the total count received in the time frame, so too many messages is also a failure.
+    * Expects a number of messages to arrive _at any consumer_ (count is across all subscribers).
+    * Matches the exact count on the messages received in the given time frame, meaning that too many or less
+    * messages than expected will result in a failure.
+    *
+    * Requires at least one consumer to be meaningful.
     */
   def expectMsgCount(count: Int, maxWait: FiniteDuration = 6.seconds): Unit = {
     probe.expectMsgAllClassOf(maxWait, Array.fill(count)(tag.runtimeClass): _*)
     probe.expectNoMsg(maxWait)
   }
 
+  /**
+    * Expects a number of messages to be published to this queue.
+    * Matches the exact count on the messages published in the given time frame, meaning that too many or less
+    * messages than expected will result in a failure.
+    *
+    * Does not require a consumer to be meaningful.
+    */
   def expectPublishCount(count: Int, maxWait: FiniteDuration = 6.seconds): Unit = {
     publishProbe.expectMsgAllClassOf(maxWait, Array.fill(count)(tag.runtimeClass): _*)
     publishProbe.expectNoMsg(maxWait)
   }
 
-  def fishForMessage(msg: T, maxWait: FiniteDuration = 6.seconds) =
+  /**
+    * Waits for a specific message to arrive _at any of the registered consumers_ for a maximum of maxWait duration.
+    * Requires at least one consumer to be meaningful.
+    */
+  def fishForMsg(msg: T, maxWait: FiniteDuration = 6.seconds) =
     probe.fishForMessage(maxWait) {
       case expected: T if expected == msg => true
       case _                              => false
     }
 
-  def fishForPublishedMessage(msg: T, maxWait: FiniteDuration = 6.seconds) =
+  /**
+    * Waits for a specific message to be published to this queue for a maximum of maxWait duration.
+    * Does not require a consumer to be meaningful.
+    */
+  def fishForPublishedMsg(msg: T, maxWait: FiniteDuration = 6.seconds) =
     publishProbe.fishForMessage(maxWait) {
       case expected: T if expected == msg => true
       case _                              => false
     }
 
   /**
-    * Regular publish of messages. Publishes to the main queue.
+    * Publish a message to this queue.
     */
   def publish(msg: T): Unit = {
     synchronized { messagesPublished = messagesPublished :+ msg }
@@ -115,7 +166,5 @@ case class InMemoryQueueTestKit[T](backoff: BackoffStrategy = ConstantBackoff(1.
     messagesPublished = Vector.empty[T]
 
     _underlying.shutdown
-
-    Await.result(system.terminate(), 10.seconds)
   }
 }

--- a/server/libs/message-bus/src/main/scala/cool/graph/messagebus/testkits/RabbitAkkaPubSubTestKit.scala
+++ b/server/libs/message-bus/src/main/scala/cool/graph/messagebus/testkits/RabbitAkkaPubSubTestKit.scala
@@ -46,7 +46,7 @@ case class RabbitAkkaPubSubTestKit[T](
   implicit val bugSnagger: BugSnagger = null
 
   val probe                        = TestProbe()
-  val logId                        = new java.util.Random().nextInt() // For log output correlation
+  val logId                        = new java.util.Random().nextInt(Integer.MAX_VALUE) // For log output correlation
   var messages: Vector[Message[T]] = Vector.empty
   var queueDef: rabbit.Queue       = _
   val exchange                     = RabbitUtils.declareExchange(amqpUri, exchangeName, 1, durable = exchangeDurable)

--- a/server/libs/message-bus/src/main/scala/cool/graph/messagebus/testkits/RabbitQueueTestKit.scala
+++ b/server/libs/message-bus/src/main/scala/cool/graph/messagebus/testkits/RabbitQueueTestKit.scala
@@ -49,7 +49,7 @@ case class RabbitQueueTestKit[T](
 
   val probe                    = TestProbe()
   val errorProbe               = TestProbe()
-  val logId                    = new java.util.Random().nextInt() // For log output correlation
+  val logId                    = new java.util.Random().nextInt(Integer.MAX_VALUE) // For log output correlation
   var messages: Vector[T]      = Vector.empty
   var errorMessages: Vector[T] = Vector.empty
   val exchange                 = RabbitUtils.declareExchange(amqpUri, exchangeName, 1, durable = exchangeDurable)

--- a/server/libs/message-bus/src/test/scala/cool/graph/messagebus/pubsub/inmemory/InMemoryAkkaPubSubSpec.scala
+++ b/server/libs/message-bus/src/test/scala/cool/graph/messagebus/pubsub/inmemory/InMemoryAkkaPubSubSpec.scala
@@ -22,12 +22,11 @@ class InMemoryAkkaPubSubSpec
     val pubSub    = InMemoryAkkaPubSub[String]()
 
     pubSub.mediator
-    Thread.sleep(2000)
 
     checkFn(pubSub, testProbe)
   }
 
-  "PubSub" should {
+  "The in-memory PubSub implementation" should {
 
     /**
       * Callback tests
@@ -35,10 +34,9 @@ class InMemoryAkkaPubSubSpec
     "call the specified callback if a message for the subscription arrives" in {
       withInMemoryAkkaPubSub { (pubsub, probe) =>
         val testCallback = (msg: Message[String]) => probe.ref ! msg
-        val subscription = pubsub.subscribe(testTopic, testCallback)
 
-        Thread.sleep(500)
-
+        pubsub.subscribe(testTopic, testCallback)
+        Thread.sleep(50)
         pubsub.publish(testTopic, testMsg)
         probe.expectMsg(Message[String](testTopic.topic, testMsg))
       }
@@ -47,10 +45,9 @@ class InMemoryAkkaPubSubSpec
     "not call the specified callback if the message doesn't match" in {
       withInMemoryAkkaPubSub { (pubsub, probe) =>
         val testCallback = (msg: Message[String]) => probe.ref ! msg
-        val subscription = pubsub.subscribe(Only("NOPE"), testCallback)
 
-        Thread.sleep(500)
-
+        pubsub.subscribe(Only("NOPE"), testCallback)
+        Thread.sleep(50)
         pubsub.publish(testTopic, testMsg)
         probe.expectNoMsg()
       }
@@ -61,8 +58,7 @@ class InMemoryAkkaPubSubSpec
         val testCallback = (msg: Message[String]) => probe.ref ! msg
         val subscription = pubsub.subscribe(testTopic, testCallback)
 
-        Thread.sleep(500)
-
+        Thread.sleep(50)
         pubsub.unsubscribe(subscription)
         pubsub.publish(testTopic, testMsg)
         probe.expectNoMsg()
@@ -72,11 +68,10 @@ class InMemoryAkkaPubSubSpec
     "send messages from different topics to the given callback when subscribed to everything" in {
       withInMemoryAkkaPubSub { (pubsub, probe) =>
         val testCallback = (msg: Message[String]) => probe.ref ! msg
-        val subscription = pubsub.subscribe(Everything, testCallback)
         val testMsg2     = "testMsg2"
 
-        Thread.sleep(500)
-
+        pubsub.subscribe(Everything, testCallback)
+        Thread.sleep(50)
         pubsub.publish(testTopic, testMsg)
         pubsub.publish(Only("testTopic2"), testMsg2)
         probe.expectMsgAllOf(Message[String](testTopic.topic, testMsg), Message[String]("testTopic2", testMsg2))
@@ -88,10 +83,8 @@ class InMemoryAkkaPubSubSpec
       */
     "send the unmarshalled message to the given actor" in {
       withInMemoryAkkaPubSub { (pubsub, probe) =>
-        val subscription = pubsub.subscribe(testTopic, probe.ref)
-
-        Thread.sleep(500)
-
+        pubsub.subscribe(testTopic, probe.ref)
+        Thread.sleep(50)
         pubsub.publish(testTopic, testMsg)
         probe.expectMsg(Message[String](testTopic.topic, testMsg))
       }
@@ -99,10 +92,8 @@ class InMemoryAkkaPubSubSpec
 
     "not send the message to the given actor if the message doesn't match" in {
       withInMemoryAkkaPubSub { (pubsub, probe) =>
-        val subscription = pubsub.subscribe(Only("NOPE"), probe.ref)
-
-        Thread.sleep(500)
-
+        pubsub.subscribe(Only("NOPE"), probe.ref)
+        Thread.sleep(50)
         pubsub.publish(testTopic, testMsg)
         probe.expectNoMsg()
       }
@@ -112,8 +103,7 @@ class InMemoryAkkaPubSubSpec
       withInMemoryAkkaPubSub { (pubsub, probe) =>
         val subscription = pubsub.subscribe(testTopic, probe.ref)
 
-        Thread.sleep(500)
-
+        Thread.sleep(50)
         pubsub.unsubscribe(subscription)
         pubsub.publish(testTopic, testMsg)
         probe.expectNoMsg()
@@ -122,11 +112,10 @@ class InMemoryAkkaPubSubSpec
 
     "send the unmarshalled messages from different topics to the given actor when subscribed to everything" in {
       withInMemoryAkkaPubSub { (pubsub, probe) =>
-        val subscription = pubsub.subscribe(Everything, probe.ref)
-        val testMsg2     = "testMsg2"
+        val testMsg2 = "testMsg2"
 
-        Thread.sleep(500)
-
+        pubsub.subscribe(Everything, probe.ref)
+        Thread.sleep(50)
         pubsub.publish(testTopic, testMsg)
         pubsub.publish(Only("testTopic2"), testMsg2)
         probe.expectMsgAllOf(Message[String](testTopic.topic, testMsg), Message[String]("testTopic2", testMsg2))
@@ -142,11 +131,8 @@ class InMemoryAkkaPubSubSpec
 
         pubsub.subscribe(testTopic, probe.ref)
         newPubSub.subscribe(testTopic, newProbe.ref)
-
-        Thread.sleep(500)
-
+        Thread.sleep(50)
         pubsub.publish(testTopic, msg)
-
         probe.expectMsg(Message[String](testTopic.topic, msg))
         newProbe.expectMsg(Message[Int](testTopic.topic, 1234))
       }
@@ -157,10 +143,9 @@ class InMemoryAkkaPubSubSpec
         val msg                             = 1234
         val converter                       = (int: Int) => int.toString
         val newPubSub: PubSubPublisher[Int] = pubsub.map[Int](converter)
-        val newProbe                        = TestProbe()
 
         pubsub.subscribe(testTopic, probe.ref)
-        Thread.sleep(500)
+        Thread.sleep(50)
         newPubSub.publish(testTopic, msg)
         probe.expectMsg(Message[String](testTopic.topic, "1234"))
       }

--- a/server/libs/message-bus/src/test/scala/cool/graph/messagebus/testkits/InMemoryAkkaPubSubTestKitSpec.scala
+++ b/server/libs/message-bus/src/test/scala/cool/graph/messagebus/testkits/InMemoryAkkaPubSubTestKitSpec.scala
@@ -1,0 +1,170 @@
+package cool.graph.messagebus.testkits
+
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import cool.graph.akkautil.SingleThreadedActorSystem
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
+import org.scalatest.concurrent.ScalaFutures
+
+class InMemoryAkkaPubSubTestKitSpec
+    extends TestKit(SingleThreadedActorSystem("pubsub-spec"))
+    with WordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with ScalaFutures {
+
+  case class TestMessage(id: String, testOpt: Option[Int], testSeq: Seq[String])
+
+  var testKit: InMemoryQueueTestKit[TestMessage] = _
+  implicit val materializer: ActorMaterializer   = ActorMaterializer()
+
+  override def beforeEach = testKit = InMemoryQueueTestKit[TestMessage]()
+  override def afterEach  = testKit.shutdown()
+
+  override def afterAll = {
+    materializer.shutdown()
+    shutdown(verifySystemShutdown = true)
+  }
+
+  "The in-memory queue testing kit" should {
+
+    /**
+      * Incoming messages expectation tests
+      */
+    "should expect an incoming message correctly" in {
+      val testMsg = TestMessage("someId1", None, Seq("1", "2"))
+
+      testKit.withTestConsumer()
+      testKit.publish(testMsg)
+      testKit.expectMsg(testMsg)
+      testKit.messagesReceived.length shouldEqual 1
+    }
+
+    "should blow up it expects a message and none arrives" in {
+      val testMsg = TestMessage("someId2", None, Seq("1", "2"))
+
+      testKit.withTestConsumer()
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectMsg(testMsg)
+      }
+    }
+
+    "should expect no message correctly" in {
+      testKit.withTestConsumer()
+      testKit.expectNoMsg()
+    }
+
+    "should blow up if no message was expected but one arrives" in {
+      val testMsg = TestMessage("someId3", None, Seq("1", "2"))
+
+      testKit.withTestConsumer()
+      testKit.publish(testMsg)
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectNoMsg()
+      }
+    }
+
+    "should expect a message count correctly" in {
+      val testMsg  = TestMessage("someId4", None, Seq("1", "2"))
+      val testMsg2 = TestMessage("someId5", Some(123), Seq("2", "1"))
+
+      testKit.withTestConsumer()
+      testKit.publish(testMsg)
+      testKit.publish(testMsg2)
+      testKit.expectMsgCount(2)
+      testKit.messagesReceived.length shouldEqual 2
+    }
+
+    "should blow up if it expects a message count and less arrive" in {
+      val testMsg = TestMessage("someId6", None, Seq("1", "2"))
+
+      testKit.withTestConsumer()
+      testKit.publish(testMsg)
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectMsgCount(2)
+      }
+    }
+
+    "should blow up if it expects a message count and more arrive" in {
+      val testMsg  = TestMessage("someId7", None, Seq("1", "2"))
+      val testMsg2 = TestMessage("someId8", Some(123), Seq("2", "1"))
+
+      testKit.withTestConsumer()
+      testKit.publish(testMsg)
+      testKit.publish(testMsg2)
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectMsgCount(1)
+      }
+    }
+
+    /**
+      * Published messages expectation tests
+      */
+    "should expect a published message correctly" in {
+      val testMsg = TestMessage("someId1", None, Seq("1", "2"))
+
+      testKit.publish(testMsg)
+      testKit.expectPublishedMsg(testMsg)
+      testKit.messagesPublished.length shouldEqual 1
+    }
+
+    "should blow up it expects a published message and none arrives" in {
+      val testMsg = TestMessage("someId2", None, Seq("1", "2"))
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectPublishedMsg(testMsg)
+      }
+    }
+
+    "should expect no published message correctly" in {
+      testKit.expectNoPublishedMsg()
+    }
+
+    "should blow up if no published message was expected but one arrives" in {
+      val testMsg = TestMessage("someId3", None, Seq("1", "2"))
+
+      testKit.publish(testMsg)
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectNoPublishedMsg()
+      }
+    }
+
+    "should expect a published message count correctly" in {
+      val testMsg  = TestMessage("someId4", None, Seq("1", "2"))
+      val testMsg2 = TestMessage("someId5", Some(123), Seq("2", "1"))
+
+      testKit.publish(testMsg)
+      testKit.publish(testMsg2)
+      testKit.expectPublishCount(2)
+      testKit.messagesPublished.length shouldEqual 2
+    }
+
+    "should blow up if it expects a published message count and less arrive" in {
+      val testMsg = TestMessage("someId6", None, Seq("1", "2"))
+
+      testKit.publish(testMsg)
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectPublishCount(2)
+      }
+    }
+
+    "should blow up if it expects a published message count and more arrive" in {
+      val testMsg  = TestMessage("someId7", None, Seq("1", "2"))
+      val testMsg2 = TestMessage("someId8", Some(123), Seq("2", "1"))
+
+      testKit.publish(testMsg)
+      testKit.publish(testMsg2)
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectPublishCount(1)
+      }
+    }
+  }
+}

--- a/server/libs/message-bus/src/test/scala/cool/graph/messagebus/testkits/InMemoryQueueTestKitSpec.scala
+++ b/server/libs/message-bus/src/test/scala/cool/graph/messagebus/testkits/InMemoryQueueTestKitSpec.scala
@@ -1,0 +1,170 @@
+package cool.graph.messagebus.testkits
+
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import cool.graph.akkautil.SingleThreadedActorSystem
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
+
+class InMemoryQueueTestKitSpec
+    extends TestKit(SingleThreadedActorSystem("pubsub-spec"))
+    with WordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with ScalaFutures {
+
+  case class TestMessage(id: String, testOpt: Option[Int], testSeq: Seq[String])
+
+  var testKit: InMemoryQueueTestKit[TestMessage] = _
+  implicit val materializer: ActorMaterializer   = ActorMaterializer()
+
+  override def beforeEach = testKit = InMemoryQueueTestKit[TestMessage]()
+  override def afterEach  = testKit.shutdown()
+
+  override def afterAll = {
+    materializer.shutdown()
+    shutdown(verifySystemShutdown = true)
+  }
+
+  "The in-memory queue testing kit" should {
+
+    /**
+      * Incoming messages expectation tests
+      */
+    "should expect an incoming message correctly" in {
+      val testMsg = TestMessage("someId1", None, Seq("1", "2"))
+
+      testKit.withTestConsumer()
+      testKit.publish(testMsg)
+      testKit.expectMsg(testMsg)
+      testKit.messagesReceived.length shouldEqual 1
+    }
+
+    "should blow up it expects a message and none arrives" in {
+      val testMsg = TestMessage("someId2", None, Seq("1", "2"))
+
+      testKit.withTestConsumer()
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectMsg(testMsg)
+      }
+    }
+
+    "should expect no message correctly" in {
+      testKit.withTestConsumer()
+      testKit.expectNoMsg()
+    }
+
+    "should blow up if no message was expected but one arrives" in {
+      val testMsg = TestMessage("someId3", None, Seq("1", "2"))
+
+      testKit.withTestConsumer()
+      testKit.publish(testMsg)
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectNoMsg()
+      }
+    }
+
+    "should expect a message count correctly" in {
+      val testMsg  = TestMessage("someId4", None, Seq("1", "2"))
+      val testMsg2 = TestMessage("someId5", Some(123), Seq("2", "1"))
+
+      testKit.withTestConsumer()
+      testKit.publish(testMsg)
+      testKit.publish(testMsg2)
+      testKit.expectMsgCount(2)
+      testKit.messagesReceived.length shouldEqual 2
+    }
+
+    "should blow up if it expects a message count and less arrive" in {
+      val testMsg = TestMessage("someId6", None, Seq("1", "2"))
+
+      testKit.withTestConsumer()
+      testKit.publish(testMsg)
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectMsgCount(2)
+      }
+    }
+
+    "should blow up if it expects a message count and more arrive" in {
+      val testMsg  = TestMessage("someId7", None, Seq("1", "2"))
+      val testMsg2 = TestMessage("someId8", Some(123), Seq("2", "1"))
+
+      testKit.withTestConsumer()
+      testKit.publish(testMsg)
+      testKit.publish(testMsg2)
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectMsgCount(1)
+      }
+    }
+
+    /**
+      * Published messages expectation tests
+      */
+    "should expect a published message correctly" in {
+      val testMsg = TestMessage("someId1", None, Seq("1", "2"))
+
+      testKit.publish(testMsg)
+      testKit.expectPublishedMsg(testMsg)
+      testKit.messagesPublished.length shouldEqual 1
+    }
+
+    "should blow up it expects a published message and none arrives" in {
+      val testMsg = TestMessage("someId2", None, Seq("1", "2"))
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectPublishedMsg(testMsg)
+      }
+    }
+
+    "should expect no published message correctly" in {
+      testKit.expectNoPublishedMsg()
+    }
+
+    "should blow up if no published message was expected but one arrives" in {
+      val testMsg = TestMessage("someId3", None, Seq("1", "2"))
+
+      testKit.publish(testMsg)
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectNoPublishedMsg()
+      }
+    }
+
+    "should expect a published message count correctly" in {
+      val testMsg  = TestMessage("someId4", None, Seq("1", "2"))
+      val testMsg2 = TestMessage("someId5", Some(123), Seq("2", "1"))
+
+      testKit.publish(testMsg)
+      testKit.publish(testMsg2)
+      testKit.expectPublishCount(2)
+      testKit.messagesPublished.length shouldEqual 2
+    }
+
+    "should blow up if it expects a published message count and less arrive" in {
+      val testMsg = TestMessage("someId6", None, Seq("1", "2"))
+
+      testKit.publish(testMsg)
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectPublishCount(2)
+      }
+    }
+
+    "should blow up if it expects a published message count and more arrive" in {
+      val testMsg  = TestMessage("someId7", None, Seq("1", "2"))
+      val testMsg2 = TestMessage("someId8", Some(123), Seq("2", "1"))
+
+      testKit.publish(testMsg)
+      testKit.publish(testMsg2)
+
+      an[AssertionError] should be thrownBy {
+        testKit.expectPublishCount(1)
+      }
+    }
+  }
+}

--- a/server/libs/message-bus/src/test/scala/cool/graph/messagebus/testkits/RabbitAkkaPubSubTestKitSpec.scala
+++ b/server/libs/message-bus/src/test/scala/cool/graph/messagebus/testkits/RabbitAkkaPubSubTestKitSpec.scala
@@ -1,9 +1,8 @@
-package cool.graph.messagebus.pubsub.rabbit
+package cool.graph.messagebus.testkits
 
 import cool.graph.bugsnag.BugSnagger
 import cool.graph.messagebus.Conversions
 import cool.graph.messagebus.pubsub.{Message, Only}
-import cool.graph.messagebus.testkits.RabbitAkkaPubSubTestKit
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
 import play.api.libs.json.Json
@@ -29,14 +28,12 @@ class RabbitAkkaPubSubTestKitSpec extends WordSpecLike with Matchers with Before
 
   override def afterEach(): Unit = testKit.stop.futureValue
 
-  // Note: Publish logic is tested implicitly within the tests.
-  "The queue testing kit" should {
+  "The rabbit pubsub testing kit" should {
 
     /**
       * Message expectation tests
       */
     "should expect a message correctly" in {
-      println(s"[PubSubTestKit][${testKit.logId}] Starting 'should expect a message correctly' test...")
       val testMsg = TestMessage("someId1", None, Seq("1", "2"))
 
       testKit.publish(testRK, testMsg)
@@ -44,7 +41,6 @@ class RabbitAkkaPubSubTestKitSpec extends WordSpecLike with Matchers with Before
     }
 
     "should blow up it expects a message and none arrives" in {
-      println(s"[PubSubTestKit][${testKit.logId}] Starting 'should blow up it expects a message and none arrives' test...")
       val testMsg = TestMessage("someId2", None, Seq("1", "2"))
 
       an[AssertionError] should be thrownBy {
@@ -57,7 +53,6 @@ class RabbitAkkaPubSubTestKitSpec extends WordSpecLike with Matchers with Before
     }
 
     "should blow up if no message was expected but one arrives" in {
-      println(s"[PubSubTestKit][${testKit.logId}] Starting 'should blow up if no message was expected but one arrives' test...")
       val testMsg = TestMessage("someId3", None, Seq("1", "2"))
 
       testKit.publish(testRK, testMsg)
@@ -68,8 +63,6 @@ class RabbitAkkaPubSubTestKitSpec extends WordSpecLike with Matchers with Before
     }
 
     "should expect a message count correctly" in {
-      println(s"[PubSubTestKit][${testKit.logId}] Starting 'should expect a message count correctly' test...")
-
       val testMsg  = TestMessage("someId4", None, Seq("1", "2"))
       val testMsg2 = TestMessage("someId5", Some(123), Seq("2", "1"))
 
@@ -80,7 +73,6 @@ class RabbitAkkaPubSubTestKitSpec extends WordSpecLike with Matchers with Before
     }
 
     "should blow up if it expects a message count and less arrive" in {
-      println(s"[PubSubTestKit][${testKit.logId}] Starting 'should blow up if it expects a message count and less arrive' test...")
       val testMsg = TestMessage("someId6", None, Seq("1", "2"))
 
       testKit.publish(testRK, testMsg)
@@ -91,7 +83,6 @@ class RabbitAkkaPubSubTestKitSpec extends WordSpecLike with Matchers with Before
     }
 
     "should blow up if it expects a message count and more arrive" in {
-      println(s"[PubSubTestKit][${testKit.logId}] Starting 'should blow up if it expects a message count and more arrive' test...")
       val testMsg  = TestMessage("someId7", None, Seq("1", "2"))
       val testMsg2 = TestMessage("someId8", Some(123), Seq("2", "1"))
 

--- a/server/libs/message-bus/src/test/scala/cool/graph/messagebus/testkits/RabbitQueueTestKitSpec.scala
+++ b/server/libs/message-bus/src/test/scala/cool/graph/messagebus/testkits/RabbitQueueTestKitSpec.scala
@@ -1,8 +1,7 @@
-package cool.graph.messagebus.queue.rabbit
+package cool.graph.messagebus.testkits
 
 import cool.graph.bugsnag.BugSnagger
 import cool.graph.messagebus.Conversions
-import cool.graph.messagebus.testkits.RabbitQueueTestKit
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
 import play.api.libs.json.Json
@@ -27,14 +26,12 @@ class RabbitQueueTestKitSpec extends WordSpecLike with Matchers with BeforeAndAf
 
   override def afterEach(): Unit = testKit.shutdown()
 
-  // Note: Publish logic is tested implicitly within the tests.
-  "The queue testing kit" should {
+  "The rabbit queue testing kit" should {
 
     /**
       * Message expectation tests
       */
     "should expect a message correctly" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should expect a message correctly' test...")
       val testMsg = TestMessage("someId1", None, Seq("1", "2"))
 
       testKit.publish(testMsg)
@@ -42,7 +39,6 @@ class RabbitQueueTestKitSpec extends WordSpecLike with Matchers with BeforeAndAf
     }
 
     "should blow up it expects a message and none arrives" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should blow up it expects a message and none arrives' test...")
       val testMsg = TestMessage("someId2", None, Seq("1", "2"))
 
       an[AssertionError] should be thrownBy {
@@ -55,7 +51,6 @@ class RabbitQueueTestKitSpec extends WordSpecLike with Matchers with BeforeAndAf
     }
 
     "should blow up if no message was expected but one arrives" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should blow up if no message was expected but one arrives' test...")
       val testMsg = TestMessage("someId3", None, Seq("1", "2"))
 
       testKit.publish(testMsg)
@@ -66,7 +61,6 @@ class RabbitQueueTestKitSpec extends WordSpecLike with Matchers with BeforeAndAf
     }
 
     "should expect a message count correctly" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should expect a message count correctly' test...")
       val testMsg  = TestMessage("someId4", None, Seq("1", "2"))
       val testMsg2 = TestMessage("someId5", Some(123), Seq("2", "1"))
 
@@ -77,7 +71,6 @@ class RabbitQueueTestKitSpec extends WordSpecLike with Matchers with BeforeAndAf
     }
 
     "should blow up if it expects a message count and less arrive" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should blow up if it expects a message count and less arrive' test...")
       val testMsg = TestMessage("someId6", None, Seq("1", "2"))
 
       testKit.publish(testMsg)
@@ -88,7 +81,6 @@ class RabbitQueueTestKitSpec extends WordSpecLike with Matchers with BeforeAndAf
     }
 
     "should blow up if it expects a message count and more arrive" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should blow up if it expects a message count and more arrive' test...")
       val testMsg  = TestMessage("someId7", None, Seq("1", "2"))
       val testMsg2 = TestMessage("someId8", Some(123), Seq("2", "1"))
 
@@ -104,7 +96,6 @@ class RabbitQueueTestKitSpec extends WordSpecLike with Matchers with BeforeAndAf
       * Error msg expectation tests
       */
     "should expect an error message correctly" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should expect an error message correctly' test...")
       val testMsg = TestMessage("someId9", None, Seq("1", "2"))
 
       testKit.publishError(testMsg)
@@ -112,7 +103,6 @@ class RabbitQueueTestKitSpec extends WordSpecLike with Matchers with BeforeAndAf
     }
 
     "should blow up it expects an error message and none arrives" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should blow up it expects an error message and none arrives' test...")
       val testMsg = TestMessage("someId10", None, Seq("1", "2"))
 
       an[AssertionError] should be thrownBy {
@@ -121,12 +111,10 @@ class RabbitQueueTestKitSpec extends WordSpecLike with Matchers with BeforeAndAf
     }
 
     "should expect no error message correctly" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should expect no error message correctly' test...")
       testKit.expectNoErrorMsg()
     }
 
     "should blow up if no error message was expected but one arrives" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should blow up if no error message was expected but one arrives' test...")
       val testMsg = TestMessage("someId11", None, Seq("1", "2"))
 
       testKit.publishError(testMsg)
@@ -137,7 +125,6 @@ class RabbitQueueTestKitSpec extends WordSpecLike with Matchers with BeforeAndAf
     }
 
     "should expect an error message count correctly" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should expect an error message count correctly' test...")
       val testMsg  = TestMessage("someId12", None, Seq("1", "2"))
       val testMsg2 = TestMessage("someId13", Some(123), Seq("2", "1"))
 
@@ -148,7 +135,6 @@ class RabbitQueueTestKitSpec extends WordSpecLike with Matchers with BeforeAndAf
     }
 
     "should blow up if it expects an error message count and less arrive" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should blow up if it expects an error message count and less arrive' test...")
       val testMsg = TestMessage("someId14", None, Seq("1", "2"))
 
       testKit.publishError(testMsg)
@@ -159,7 +145,6 @@ class RabbitQueueTestKitSpec extends WordSpecLike with Matchers with BeforeAndAf
     }
 
     "should blow up if it expects an error message count and more arrive" in {
-      println(s"[TestKit][${testKit.logId}] Starting 'should blow up if it expects an error message count and more arrive' test...")
       val testMsg  = TestMessage("someId15", None, Seq("1", "2"))
       val testMsg2 = TestMessage("someId16", Some(123), Seq("2", "1"))
 


### PR DESCRIPTION
Context: Having RabbitMQ in the tests is heavyweight and sometimes hard to handle correctly, even with the testkits. Additionally, we do not need to test the message bus RabbitMQ adapter in the tests, as it is sufficiently tested in the message bus rabbit tests - we only want to test the business logic.

Solution: Use lightweight, actor-backed in-memory testkits for the message bus interfaces for test speedup and robustness.

Work items:
- [x] More code documentation for testkits.
- [x] Finish implementation of in-memory messagebus testkits.
- [x] Add missing tests for in-memory queue testkit.
- [ ] Add missing tests for in-memory pubsub testkit.
- [ ] Replace rabbit testkits with in-memory testkits.
- [ ] Optional: Consolidate various testkit interfaces into a trait.

Additional notes:
- Various refactorings for testkits included to make the interface more uniform.
- The in-memory interface semantics differ slightly from the older rabbit interfaces: Expecting a message now reasons over the messages actually received by a subscriber / consumer, as opposed to the `-published` counterpart, which reasons over the incoming messages into the pubsub / queue. The old testkits did not distinguish those cases.