### PR TITLE
Fix flaky request pipeline behaviour

### DIFF
--- a/server/libs/akka-utils/src/main/scala/cool/graph/akkautil/http/SimpleHttpClient.scala
+++ b/server/libs/akka-utils/src/main/scala/cool/graph/akkautil/http/SimpleHttpClient.scala
@@ -25,10 +25,15 @@ case class SimpleHttpClient()(implicit val system: ActorSystem, materializer: Ac
   import system.dispatcher
 
   type ResponseUnmarshaller[T] = (HttpResponse) => Future[T]
+  type StatusCodeValidator     = (Int) => Boolean
 
   private val akkaClient = Http()(system)
 
-  def get(uri: String, headers: Seq[(String, String)] = Seq.empty): Future[SimpleHttpResponse] = {
+  def get(
+      uri: String,
+      headers: Seq[(String, String)] = Seq.empty,
+      statusCodeValidator: StatusCodeValidator = defaultStatusCodeValidator
+  ): Future[SimpleHttpResponse] = {
     parseHeaders(headers).flatMap { akkaHeaders =>
       val akkaRequest = HttpRequest(
         uri = uri,
@@ -36,15 +41,26 @@ case class SimpleHttpClient()(implicit val system: ActorSystem, materializer: Ac
         headers = akkaHeaders
       )
 
-      execute(akkaRequest)
+      execute(akkaRequest, statusCodeValidator)
     }
   }
 
-  def postJson[T](uri: String, body: T, headers: Seq[(String, String)] = Seq.empty)(implicit bodyWrites: Writes[T]) = {
-    post(uri, Json.toJson(body).toString(), ContentTypes.`application/json`, headers)
+  def postJson[T](
+      uri: String,
+      body: T,
+      headers: Seq[(String, String)] = Seq.empty,
+      statusCodeValidator: StatusCodeValidator = defaultStatusCodeValidator
+  )(implicit bodyWrites: Writes[T]) = {
+    post(uri, Json.toJson(body).toString(), ContentTypes.`application/json`, headers, statusCodeValidator)
   }
 
-  def post(uri: String, body: String, contentType: ContentType.NonBinary = ContentTypes.`text/plain(UTF-8)`, headers: Seq[(String, String)] = Seq.empty) = {
+  def post(
+      uri: String,
+      body: String,
+      contentType: ContentType.NonBinary = ContentTypes.`text/plain(UTF-8)`,
+      headers: Seq[(String, String)] = Seq.empty,
+      statusCodeValidator: StatusCodeValidator = defaultStatusCodeValidator
+  ) = {
     parseHeaders(headers).flatMap { akkaHeaders =>
       val akkaRequest = HttpRequest(
         uri = uri,
@@ -53,11 +69,19 @@ case class SimpleHttpClient()(implicit val system: ActorSystem, materializer: Ac
         entity = HttpEntity(contentType, body)
       )
 
-      execute(akkaRequest)
+      execute(akkaRequest, statusCodeValidator)
     }
   }
 
-  protected def execute(req: HttpRequest): Future[SimpleHttpResponse] = {
+  /**
+    * Standard validator for status codes. Checks if the code is from 200 - 299.
+    *
+    * @param statusCode The status code to validate
+    * @return true if the status code is considered valid, false otherwise.
+    */
+  def defaultStatusCodeValidator(statusCode: Int): Boolean = 200 >= statusCode && statusCode < 300
+
+  protected def execute(req: HttpRequest, isValidStatusCode: StatusCodeValidator): Future[SimpleHttpResponse] = {
     akkaClient.singleRequest(req).flatMap { response =>
       Unmarshal(response)
         .to[String]
@@ -71,7 +95,7 @@ case class SimpleHttpClient()(implicit val system: ActorSystem, materializer: Ac
             Future.failed(e)
         }
         .flatMap { simpleResponse =>
-          if (response.status.isSuccess()) {
+          if (isValidStatusCode(response.status.intValue())) {
             Future.successful(simpleResponse)
           } else {
             Future.failed(FailedResponseCodeError(s"Server responded with ${response.status.intValue()}", simpleResponse))
@@ -91,6 +115,12 @@ case class SimpleHttpClient()(implicit val system: ActorSystem, materializer: Ac
     }
   }
 
+  /**
+    * Parses a collection of headers to akka http headers.
+    *
+    * @param headers Sequence of tuples representing the headers.
+    * @return A future containing a collection of the akka http headers.
+    */
   def parseHeaders(headers: Seq[(String, String)]): Future[Seq[HttpHeader]] = Future {
     headers.map { (h: (String, String)) =>
       HttpHeader.parse(h._1, h._2) match {

--- a/server/libs/akka-utils/src/test/scala/cool/graph/akkautil/http/SimpleHttpClientSpec.scala
+++ b/server/libs/akka-utils/src/test/scala/cool/graph/akkautil/http/SimpleHttpClientSpec.scala
@@ -99,6 +99,16 @@ class SimpleHttpClientSpec extends WordSpecLike with Matchers with ScalaFutures 
           }
         }
       }
+
+      "that use a custom status code validator and return a 500 should not fail if the validator passes" in {
+        withStubServer(List(failingGetStub)).withArg { server =>
+          val uri = s"http://localhost:${server.port}/some/path"
+
+          whenReady(client.get(uri, statusCodeValidator = (_) => true)) { (response: SimpleHttpResponse) =>
+            response.status shouldEqual 500
+          }
+        }
+      }
     }
 
     "handle POST requests" which {
@@ -160,6 +170,17 @@ class SimpleHttpClientSpec extends WordSpecLike with Matchers with ScalaFutures 
           whenReady(client.post(uri, body)) { (response: SimpleHttpResponse) =>
             response.status shouldEqual 200
             response.bodyAs[Int] shouldEqual Success(2)
+          }
+        }
+      }
+
+      "that use a custom status code validator and return a 500 should not fail if the validator passes" in {
+        withStubServer(List(failingPostStub)).withArg { server =>
+          val uri  = s"http://localhost:${server.port}/some/path"
+          val body = PostTestClass("testData")
+
+          whenReady(client.postJson(uri, body, statusCodeValidator = (_) => true)) { (response: SimpleHttpResponse) =>
+            response.status shouldEqual 500
           }
         }
       }


### PR DESCRIPTION
Sometimes the request pipeline returns 5003 (BadBody) instead of 5000 (BadStatusCode) if the function returned a non-2xx status code.

- [x] Expand the http client with custom status code validation.
- [x] Investigate / fix flaky request pipeline behaviour.

Findings: Akka Http treated redirects as success in the .isSuccess call. Changing the behaviour to check between 200 (inclusive) and 300 (exclusive) apparently fixes the issue.