### PR TITLE
Add type to invalid name error message.

### DIFF
--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/client/CreateColumn.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/client/CreateColumn.scala
@@ -29,7 +29,7 @@ case class CreateColumn(projectId: String, model: Model, field: Field) extends C
 
   override def verify(): Future[Try[MutactionVerificationSuccess]] = {
     NameConstraints.isValidFieldName(field.name) match {
-      case false => Future.successful(Failure(UserInputErrors.InvalidName(name = field.name)))
+      case false => Future.successful(Failure(UserInputErrors.InvalidName(name = field.name, entityType = " field")))
       case true  => Future.successful(Success(MutactionVerificationSuccess()))
     }
   }

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/client/CreateModelTable.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/client/CreateModelTable.scala
@@ -20,7 +20,7 @@ case class CreateModelTable(projectId: String, model: Model) extends ClientSqlSc
     val validationResult = if (NameConstraints.isValidModelName(model.name)) {
       Success(MutactionVerificationSuccess())
     } else {
-      Failure(UserInputErrors.InvalidName(name = model.name))
+      Failure(UserInputErrors.InvalidName(name = model.name, entityType = " model"))
     }
 
     Future.successful(validationResult)

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/CreateModel.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/CreateModel.scala
@@ -36,11 +36,11 @@ case class CreateModel(project: Project, model: Model) extends SystemSqlMutactio
 
   override def verify(): Future[Try[MutactionVerificationSuccess]] = {
     if (!NameConstraints.isValidModelName(model.name)) {
-      return Future.successful(Failure(UserInputErrors.InvalidName(name = model.name)))
+      return Future.successful(Failure(UserInputErrors.InvalidName(name = model.name, entityType = " model")))
     }
 
     if (CustomScalarTypes.isScalar(model.name)) {
-      return Future.successful(Failure(UserInputErrors.InvalidName(name = model.name)))
+      return Future.successful(Failure(UserInputErrors.InvalidName(name = model.name, entityType = " model")))
     }
 
     if (project.getModelByName(model.name).exists(_.id != model.id)) {

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/CreateModelWithoutSystemFields.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/CreateModelWithoutSystemFields.scala
@@ -35,8 +35,8 @@ case class CreateModelWithoutSystemFields(project: Project, model: Model) extend
   override def verify(): Future[Try[MutactionVerificationSuccess]] = {
     Future.successful(
       () match {
-        case _ if !NameConstraints.isValidModelName(model.name)               => Failure(UserInputErrors.InvalidName(name = model.name))
-        case _ if CustomScalarTypes.isScalar(model.name)                      => Failure(UserInputErrors.InvalidName(name = model.name))
+        case _ if !NameConstraints.isValidModelName(model.name)               => Failure(UserInputErrors.InvalidName(name = model.name, entityType = " model"))
+        case _ if CustomScalarTypes.isScalar(model.name)                      => Failure(UserInputErrors.InvalidName(name = model.name, entityType = " model"))
         case _ if project.getModelByName(model.name).exists(_.id != model.id) => Failure(UserInputErrors.ModelWithNameAlreadyExists(name = model.name))
         case _                                                                => Success(MutactionVerificationSuccess())
 

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/CreateRelation.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/CreateRelation.scala
@@ -52,7 +52,7 @@ case class CreateRelation(project: Project,
   override def verify(): Future[Try[MutactionVerificationSuccess]] = {
     () match {
       case _ if !NameConstraints.isValidRelationName(relation.name) =>
-        Future.successful(Failure(UserInputErrors.InvalidName(name = relation.name)))
+        Future.successful(Failure(UserInputErrors.InvalidName(name = relation.name, entityType = " relation")))
 
       case _ if project.relations.exists(x => x.name.toLowerCase == relation.name.toLowerCase && x.id != relation.id) =>
         Future.successful(Failure(UserInputErrors.RelationNameAlreadyExists(relation.name)))

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/UpdateField.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/UpdateField.scala
@@ -173,7 +173,7 @@ object UpdateField {
     lazy val isRequiredManyRelation             = field.relation.isDefined && field.isList && field.isRequired
 
     () match {
-      case _ if isInvalidFieldName                           => Failure(UserInputErrors.InvalidName(name = field.name))
+      case _ if isInvalidFieldName                           => Failure(UserInputErrors.InvalidName(name = field.name, entityType = " field"))
       case _ if enumValueValidation.isFailure                => enumValueValidation
       case _ if defaultAndMigrationValueValidation.isFailure => defaultAndMigrationValueValidation
       case _ if isRequiredManyRelation                       => Failure(UserInputErrors.ListRelationsCannotBeRequired(field.name))

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/UpdateModel.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/UpdateModel.scala
@@ -27,8 +27,8 @@ case class UpdateModel(project: Project, oldModel: Model, model: Model) extends 
   override def verify(): Future[Try[MutactionVerificationSuccess]] = {
     Future.successful(() match {
       case _ if oldModel.isSystem && oldModel.name != model.name            => Failure(UserInputErrors.CantRenameSystemModels(name = oldModel.name))
-      case _ if !NameConstraints.isValidModelName(model.name)               => Failure(UserInputErrors.InvalidName(name = model.name))
-      case _ if CustomScalarTypes.isScalar(model.name)                      => Failure(UserInputErrors.InvalidName(name = model.name))
+      case _ if !NameConstraints.isValidModelName(model.name)               => Failure(UserInputErrors.InvalidName(name = model.name, entityType = " model"))
+      case _ if CustomScalarTypes.isScalar(model.name)                      => Failure(UserInputErrors.InvalidName(name = model.name, entityType = " model"))
       case _ if project.getModelByName(model.name).exists(_.id != model.id) => Failure(UserInputErrors.ModelWithNameAlreadyExists(model.name))
       case _                                                                => Success(MutactionVerificationSuccess())
     })

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/UpdateRelation.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/UpdateRelation.scala
@@ -28,9 +28,10 @@ case class UpdateRelation(oldRelation: Relation, relation: Relation, project: Pr
       project.relations.exists(existing => existing.name.toLowerCase == relation.name.toLowerCase && existing.id != relation.id)
 
     () match {
-      case _ if !NameConstraints.isValidRelationName(relation.name) => Future.successful(Failure(UserInputErrors.InvalidName(name = relation.name)))
-      case _ if otherRelationWithNameExists                         => Future.successful(Failure(UserInputErrors.RelationNameAlreadyExists(relation.name)))
-      case _                                                        => Future.successful(Success(MutactionVerificationSuccess()))
+      case _ if !NameConstraints.isValidRelationName(relation.name) =>
+        Future.successful(Failure(UserInputErrors.InvalidName(name = relation.name, entityType = " relation")))
+      case _ if otherRelationWithNameExists => Future.successful(Failure(UserInputErrors.RelationNameAlreadyExists(relation.name)))
+      case _                                => Future.successful(Success(MutactionVerificationSuccess()))
     }
   }
 }

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/validations/EnumValueValidation.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/validations/EnumValueValidation.scala
@@ -48,9 +48,10 @@ object EnumValueValidation extends SprayJsonExtensions {
     lazy val invalidEnumValueNames = enumValues.filter(!NameConstraints.isValidEnumValueName(_))
 
     () match {
-      case _ if enumValues.isEmpty             => Failure(UserInputErrors.MissingEnumValues())
-      case _ if invalidEnumValueNames.nonEmpty => Failure(UserInputErrors.InvalidNameMustStartUppercase(invalidEnumValueNames.mkString(",")))
-      case _                                   => Success(MutactionVerificationSuccess())
+      case _ if enumValues.isEmpty => Failure(UserInputErrors.MissingEnumValues())
+      case _ if invalidEnumValueNames.nonEmpty =>
+        Failure(UserInputErrors.InvalidNameMustStartUppercase(invalidEnumValueNames.mkString(","), entityType = "n enum"))
+      case _ => Success(MutactionVerificationSuccess())
     }
   }
 

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/validations/ProjectValidations.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/validations/ProjectValidations.scala
@@ -17,7 +17,7 @@ case class ProjectValidations(client: Client, project: Project, projectQueries: 
   def verify(): Future[Try[MutactionVerificationSuccess]] = {
     () match {
       case _ if !NameConstraints.isValidProjectName(project.name) =>
-        Future.successful(Failure[MutactionVerificationSuccess](UserInputErrors.InvalidName(name = project.name)))
+        Future.successful(Failure[MutactionVerificationSuccess](UserInputErrors.InvalidName(name = project.name, entityType = " project")))
 
       case _ if project.alias.isDefined && !NameConstraints.isValidProjectAlias(project.alias.get) =>
         Future.successful(Failure(UserInputErrors.InvalidProjectAlias(alias = project.alias.get)))

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/validations/TypeNameValidation.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/internal/validations/TypeNameValidation.scala
@@ -30,7 +30,7 @@ object TypeNameValidation {
     val enumWithNameExists = project.getEnumByName(typeName).isDefined
     val isValidTypeName    = validateName(typeName)
     if (!isValidTypeName) {
-      Failure(InvalidName(typeName))
+      Failure(InvalidName(typeName, entityType = "n enum"))
     } else if (enumWithNameExists) {
       Failure(TypeAlreadyExists(typeName))
     } else {

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutations/PushMutation.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutations/PushMutation.scala
@@ -74,7 +74,7 @@ case class PushMutation(
 
   override def verifyActions(): Future[List[Try[MutactionVerificationSuccess]]] = {
     super.verifyActions().map { verifications =>
-      verifications.map {
+      val verificationResult = verifications.map {
         case Failure(error: Throwable) =>
           errors = errors :+ extractErrors(error)
           verbalDescriptions = List.empty
@@ -84,6 +84,8 @@ case class PushMutation(
         case verification =>
           verification
       }
+      errors = errors.distinct
+      verificationResult
     }
   }
 
@@ -91,15 +93,15 @@ case class PushMutation(
     case sysError: WithSchemaError =>
       val fallbackError = SchemaError.global(sysError.getMessage)
       sysError.schemaError.getOrElse(fallbackError)
+
     case e: Throwable =>
       SchemaError.global(e.getMessage)
   }
 
   override def performActions(requestContext: Option[SystemRequestContextTrait]): Future[List[MutactionExecutionResult]] = {
-    if (args.isDryRun) {
-      Future.successful(List(MutactionExecutionSuccess()))
-    } else {
-      super.performActions(requestContext)
+    args.isDryRun match {
+      case true  => Future.successful(List(MutactionExecutionSuccess()))
+      case false => super.performActions(requestContext)
     }
   }
 

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutations/PushMutation.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutations/PushMutation.scala
@@ -53,7 +53,7 @@ case class PushMutation(
         errors = List(
           SchemaError(
             "Global",
-            "Only projects that have been ejected can make use of the CLI's deploy function. More details: https://docs-next.graph.cool/reference/service-definition/legacy-console-projects-aemieb1aev"
+            "Only projects that have been ejected can make use of the CLI's deploy function. More details: https://www.graph.cool/docs/reference/service-definition/legacy-console-projects-aemieb1aev/"
           ))
         actions
 

--- a/server/backend-shared/src/main/scala/cool/graph/shared/errors/Errors.scala
+++ b/server/backend-shared/src/main/scala/cool/graph/shared/errors/Errors.scala
@@ -219,11 +219,12 @@ object UserInputErrors {
     }
   }
 
-  case class InvalidName(name: String)                   extends SystemApiError(InvalidNames.default(name), 2008)
-  case class InvalidNameMustStartUppercase(name: String) extends SystemApiError(InvalidNames.mustStartUppercase(name), 2008)
+  case class InvalidName(name: String, entityType: String)                   extends SystemApiError(InvalidNames.default(name, entityType), 2008)
+  case class InvalidNameMustStartUppercase(name: String, entityType: String) extends SystemApiError(InvalidNames.mustStartUppercase(name, entityType), 2008)
   object InvalidNames {
-    def mustStartUppercase(name: String): String = s"'${default(name)} It must begin with an uppercase letter. It may contain letters and numbers."
-    def default(name: String): String            = s"'$name' is not a valid name."
+    def mustStartUppercase(name: String, entityType: String): String =
+      s"'${default(name, entityType)} It must begin with an uppercase letter. It may contain letters and numbers."
+    def default(name: String, entityType: String): String = s"'$name' is not a valid name for a$entityType."
   }
 
   case class FieldAreadyExists(name: String) extends SystemApiError(s"A field with the name '$name' already exists", 2009)


### PR DESCRIPTION
Fix for https://github.com/graphcool/framework/issues/994

The invalid name error was very generic and did not mention the type. It will now specify whether it was a model, field, relation or enum that had a naming convention violation.

Since several mutactions can throw the same naming violation error in one deploy we now also filter the error messages for duplicates.