### PR TITLE
Fix HTTP resolvers

### DIFF
--- a/server/client-shared/src/main/scala/cool/graph/client/requestPipeline/FunctionExecutor.scala
+++ b/server/client-shared/src/main/scala/cool/graph/client/requestPipeline/FunctionExecutor.scala
@@ -73,7 +73,7 @@ class FunctionExecutor(implicit val inj: Injector) extends Injectable {
             headers
           )
           .flatMap { (response: SimpleHttpResponse) =>
-            handleSuccessfulResponse(project, response.underlying, function, acceptEmptyResponse = response.status == 204)
+            handleSuccessfulResponse(project, response.body.getOrElse(""), function, acceptEmptyResponse = response.status == 204)
           }
           .recover {
             case e: FailedResponseCodeError => Bad(FunctionReturnedBadStatus(e.response.status, e.response.body.getOrElse("")))
@@ -141,15 +141,6 @@ class FunctionExecutor(implicit val inj: Injector) extends Injectable {
       case Bad(_: FunctionReturnedBadBody)               => throw FunctionReturnedInvalidBody(executionId = requestId)
       case Bad(FunctionReturnedStringError(errorMsg, _)) => throw FunctionReturnedErrorMessage(errorMsg)
       case Bad(FunctionReturnedJsonError(json, _))       => throw FunctionReturnedErrorObject(json)
-    }
-  }
-
-  private def handleSuccessfulResponse(project: Project, response: HttpResponse, function: models.Function, acceptEmptyResponse: Boolean)(
-      implicit actorSystem: ActorSystem,
-      materializer: ActorMaterializer): Future[FunctionSuccess Or FunctionError] = {
-
-    Unmarshal(response).to[String].flatMap { bodyString =>
-      handleSuccessfulResponse(project, bodyString, function, acceptEmptyResponse)
     }
   }
 

--- a/server/libs/akka-utils/src/main/scala/cool/graph/akkautil/http/SimpleHttpClient.scala
+++ b/server/libs/akka-utils/src/main/scala/cool/graph/akkautil/http/SimpleHttpClient.scala
@@ -24,8 +24,6 @@ import scala.util.{Failure, Success, Try}
 case class SimpleHttpClient()(implicit val system: ActorSystem, materializer: ActorMaterializer) {
   import system.dispatcher
 
-  type ResponseUnmarshaller[T] = (HttpResponse) => Future[T]
-
   private val akkaClient = Http()(system)
 
   def get(uri: String, headers: Seq[(String, String)] = Seq.empty): Future[SimpleHttpResponse] = {


### PR DESCRIPTION
Prevent Akka HTTP double unmarshal (which results in a streaming error).