### PR TITLE
Fix typos in resolvers documentation

### DIFF
--- a/docs/04-Reference/05-Functions/05-Resolvers.md
+++ b/docs/04-Reference/05-Functions/05-Resolvers.md
@@ -60,7 +60,7 @@ enum TemperatureUnit {
 }
 ```
 
-`loadWeather ` is invoked _after_ a `User` node was created and is defined as a _webhook_. It receives as input the requested `TemperatureUnit` (as this is the only argument for the `weather` field on the `Query` type) and returns a new type called `Weather`.
+`loadWeather ` is invoked when a `weather` query is run and is defined as a _webhook_. It receives as input the requested `TemperatureUnit` (as this is the only argument for the `weather` field on the `Query` type) and returns a new type called `Weather`.
 
 ### Properties
 

--- a/docs/04-Reference/05-Functions/05-Resolvers.md
+++ b/docs/04-Reference/05-Functions/05-Resolvers.md
@@ -32,7 +32,7 @@ When you want to create a resolver function in your Graphcool service, you need 
 
 ### Example
 
-Here is an example of a subscription function:
+Here is an example of a resolver function:
 
 ```yaml
 functions:

--- a/docs/04-Reference/05-Functions/05-Resolvers.md
+++ b/docs/04-Reference/05-Functions/05-Resolvers.md
@@ -55,7 +55,7 @@ type Weather {
 }
 
 enum TemperatureUnit {
-  CELCIUS
+  CELSIUS
   FAHRENHEIT
 }
 ```


### PR DESCRIPTION
`subscription` -> `resolver`
`CELCIUS` -> `CELSIUS` (https://en.wikipedia.org/wiki/Celcius_(disambiguation))
Updated text that had been copied from the `Subscriptions` document that does not apply here