### PR TITLE
No online authorization required for local cluster commands

### DIFF
--- a/cli/packages/graphcool-cli-core/src/commands/info/index.ts
+++ b/cli/packages/graphcool-cli-core/src/commands/info/index.ts
@@ -20,11 +20,12 @@ export default class InfoCommand extends Command {
     }),
   }
   async run() {
-    await this.auth.ensureAuth()
     let { target } = this.flags
 
     const { id } = await this.env.getTarget(target)
     const targetName = target || 'default'
+
+    await this.auth.ensureAuth()    
 
     const projects: Project[] = await this.client.fetchProjects()
 

--- a/cli/packages/graphcool-cli-core/src/commands/logs/function.ts
+++ b/cli/packages/graphcool-cli-core/src/commands/logs/function.ts
@@ -24,7 +24,6 @@ export default class FunctionLogs extends Command {
     }),
   }
   async run() {
-    await this.auth.ensureAuth()
     const { tail, target } = this.flags
     const functionName = this.flags.function
 
@@ -32,6 +31,8 @@ export default class FunctionLogs extends Command {
     debug(`function name ${functionName}`)
     debug(`service id ${id}`)
 
+    await this.auth.ensureAuth()
+    
     if (!functionName) {
       await this.provideAllFunctionLogs(id, tail)
     } else {

--- a/cli/packages/graphcool-cli-core/src/commands/root-token/index.ts
+++ b/cli/packages/graphcool-cli-core/src/commands/root-token/index.ts
@@ -26,10 +26,11 @@ export default class GetRootToken extends Command {
   ]
 
   async run() {
-    await this.auth.ensureAuth()
     const { target } = this.flags
     const { id } = await this.env.getTarget(target)
     const token = this.args!.token
+
+    await this.auth.ensureAuth()
 
     const pats = await this.client.getPats(id)
     if (token) {


### PR DESCRIPTION
Fixes #1067.

Applies to `gc logs`, `gc info` and `gc root-token`.