### PR TITLE
Improve messages from root-token

### DIFF
--- a/cli/packages/graphcool-cli-core/src/commands/root-token/index.ts
+++ b/cli/packages/graphcool-cli-core/src/commands/root-token/index.ts
@@ -28,15 +28,18 @@ export default class GetRootToken extends Command {
   async run() {
     await this.auth.ensureAuth()
     const { target } = this.flags
-    const { id } = await this.env.getTarget(target)
+    const { id, cluster } = await this.env.getTarget(target)
     const token = this.args!.token
 
+    const projectName = await this.client.getProjectName(id)
     const pats = await this.client.getPats(id)
     if (token) {
       const foundPat = pats.find(pat => pat.name === token)
       if (!foundPat) {
         this.out.error(
-          `There is no root token with the name ${token} in service ${id}`,
+          `There is no root token with the name ${token} in service '${chalk.bold(
+            projectName,
+          )}' (${cluster}/${id})`,
         )
       } else {
         this.out.log(prettyPat(foundPat))
@@ -44,13 +47,15 @@ export default class GetRootToken extends Command {
     } else {
       if (pats.length === 0) {
         this.out.log(
-          `There are no root tokens defined for service ${chalk.bold(
-            id,
-          )}`,
+          `There are no root tokens defined for service '${chalk.bold(
+            projectName,
+          )}' (${cluster}/${id})`,
         )
       } else {
         this.out.log(
-          chalk.blue(`\nRoot Tokens for service ${chalk.bold(id)}:`),
+          chalk.blue(`\nRoot Tokens for service '${chalk.bold(
+            projectName,
+          )}' (${cluster}/${id}):`),
         )
         this.out.log(
           pats.map(p => chalk.gray('- ') + chalk.bold(p.name)).join('\n'),


### PR DESCRIPTION
This PR depends on:
- [ ] `proposal/accepted` on #647

Fixes #647. Adds project name and cluster to output messages from `gc root-token`.