### PR TITLE
Update 01-Node.md

### DIFF
--- a/docs/01-Quickstart/02-Backend/02-Node/01-Node.md
+++ b/docs/01-Quickstart/02-Backend/02-Node/01-Node.md
@@ -212,6 +212,7 @@ Navigate to the `gateway` directory and start the server:
 
 ```bash(path="gateway")
 cd ../gateway
+yarn add graphql
 yarn install
 yarn start
 ```


### PR DESCRIPTION
To avoid the error  when query from API gateway...

---- ERROR ----
[nodemon] starting `node index.js`
Server running. Open http://localhost:3000/playground to run queries.
Error: Schema must be an instance of GraphQLSchema. Also ensure that there are not multiple versions of GraphQL installed in your node_modules directory...."