### PR TITLE
Fix docs: rename generateAuthToken to generateNodeToken

### DIFF
--- a/docs/04-Reference/06-Auth/02-Authentication/02-Authentication-Tokens.md
+++ b/docs/04-Reference/06-Auth/02-Authentication/02-Authentication-Tokens.md
@@ -44,7 +44,7 @@ A node token always needs to be associated with a particular node (often of type
 ### Generating a node token with `graphcool-lib`
 
 
-You can use the [`generateAuthToken`](https://github.com/graphcool/graphcool-lib#generatenodetokennodeid-modelname) function in [`graphcool-lib`](https://github.com/graphcool/graphcool-lib) to generate a new node token.
+You can use the [`generateNodeToken`](https://github.com/graphcool/graphcool-lib#generatenodetokennodeid-modelname) function in [`graphcool-lib`](https://github.com/graphcool/graphcool-lib) to generate a new node token.
 
 Here is how it works:
 


### PR DESCRIPTION
If I understand it correctly, [is `generateAuthToken` deprecated](https://github.com/graphcool/framework/issues/874).

(There is also an open [PR in the graphcool-lib](https://github.com/graphcool/graphcool-lib/pull/15) repo that fixes the example in the graphcool-lib README)