### PR TITLE
fixed print-out typo

### DIFF
--- a/cli/packages/graphcool-cli-core/src/commands/invoke/local.ts
+++ b/cli/packages/graphcool-cli-core/src/commands/invoke/local.ts
@@ -143,7 +143,7 @@ export default class InvokeLocal extends Command {
         )
         this.out.log(
           chalk.blue.bold(
-            `graphcool invoke local -f ${fnName} -j ${relativeLastEventPath}\n`,
+            `graphcool invoke-local -f ${fnName} -j ${relativeLastEventPath}\n`,
           ),
         )
         event = lastEventJson


### PR DESCRIPTION
when invoking a local function the CLI suggests an incorrect command: "invoke local", instead of "invoke-local"