### PR TITLE
The ResetProjectDataMutation should wipe the RelayIds as well

### DIFF
--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/client/DeleteAllRelayIds.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutactions/client/DeleteAllRelayIds.scala
@@ -1,0 +1,13 @@
+package cool.graph.system.mutactions.client
+
+import cool.graph._
+import cool.graph.client.database.DatabaseMutationBuilder
+import cool.graph.shared.models.Model
+
+import scala.concurrent.Future
+
+case class DeleteAllRelayIds(projectId: String) extends ClientSqlSchemaChangeMutaction {
+
+  override def execute: Future[ClientSqlStatementResult[Any]] =
+    Future.successful(ClientSqlStatementResult(sqlAction = DatabaseMutationBuilder.deleteAllDataItems(projectId, "_RelayId")))
+}

--- a/server/backend-api-system/src/main/scala/cool/graph/system/mutations/ResetProjectDataMutation.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/mutations/ResetProjectDataMutation.scala
@@ -3,7 +3,7 @@ package cool.graph.system.mutations
 import cool.graph.shared.database.InternalAndProjectDbs
 import cool.graph.shared.models
 import cool.graph.shared.models._
-import cool.graph.system.mutactions.client.{DeleteAllDataItems, DeleteAllRelations}
+import cool.graph.system.mutactions.client.{DeleteAllDataItems, DeleteAllRelations, DeleteAllRelayIds}
 import cool.graph.{InternalProjectMutation, Mutaction}
 import sangria.relay.Mutation
 import scaldi.Injector
@@ -26,6 +26,10 @@ case class ResetProjectDataMutation(
     val removeDataItems = project.models.map(model => DeleteAllDataItems(projectId = project.id, model = model))
 
     actions ++= removeDataItems
+
+    val removeRelayIds = DeleteAllRelayIds(projectId = project.id)
+
+    actions :+= removeRelayIds
 
     actions
   }

--- a/server/backend-shared/src/main/scala/cool/graph/client/database/ProjectDataresolver.scala
+++ b/server/backend-shared/src/main/scala/cool/graph/client/database/ProjectDataresolver.scala
@@ -46,6 +46,11 @@ class ProjectDataresolver(override val project: Project, override val requestCon
     performWithTiming("countByModel", readonlyClientDatabase.run(readOnlyInt(query))).map(_.head)
   }
 
+  def countRelayIds(args: Option[QueryArguments] = None): Future[Int] = {
+    val query = DatabaseQueryBuilder.countAllFromModel(project.id, "_RelayId", args)
+    performWithTiming("countByModel", readonlyClientDatabase.run(readOnlyInt(query))).map(_.head)
+  }
+
   def existsByModelAndId(model: Model, id: String): Future[Boolean] = {
     val query = DatabaseQueryBuilder.existsByModelAndId(project.id, model.name, id)
     performWithTiming("existsByModelAndId", readonlyClientDatabase.run(readOnlyBoolean(query))).map(_.head)


### PR DESCRIPTION
Otherwise there will be foreign key constraint problems when wiped model ids are entered again.