### PR TITLE
Handle for a missing .graphcool directory

### DIFF
--- a/cli/packages/graphcool-cli-engine/src/Environment.ts
+++ b/cli/packages/graphcool-cli-engine/src/Environment.ts
@@ -323,7 +323,7 @@ It has been renamed to ${oldPath}. The up-to-date format has been written to ${r
   migrateGlobalFiles() {
     const dotFilePath = path.join(this.config.home, '.graphcool')
     const dotExists = fs.pathExistsSync(dotFilePath)
-    if (fs.lstatSync(dotFilePath).isDirectory()) {
+    if (dotExists && fs.lstatSync(dotFilePath).isDirectory()) {
       return
     }
     const rcHomePath = path.join(this.config.home, '.graphcoolrc')


### PR DESCRIPTION
Fixes #1451

The `lstat` throws an exception when trying to access no existing file/directory. Another way would be `try/catch` block, but since there is already check for `exists` then this is enough.